### PR TITLE
Workspace Factory #3: Move Category to Index

### DIFF
--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -296,46 +296,41 @@ FactoryController.prototype.changeName = function() {
 /**
  * Tied to arrow up and arrow down buttons. Swaps with the category above or
  * below the currently selected category (offset categories away from the
- * current category).
- * TODO(edauterman): Refactor to insert a category at a specific index (using
- * Closure TreeControl).
+ * current category). Updates state to enable the correct category editing
+ * buttons.
  *
  * @param {int} offset The index offset from the currently selected category
  * to swap with. Positive if the category to be swapped with is below, negative
  * if the category to be swapped with is above.
  */
 FactoryController.prototype.moveCategory = function(offset) {
-  // Get categories.
   var curr = this.model.getSelected();
   if (!curr) {  // Return if no selected category.
     return;
   }
+  var currIndex = this.model.getIndexByCategoryId(curr.id);
   var swapIndex = this.model.getIndexByCategoryId(curr.id) + offset;
   var swap = this.model.getCategoryByIndex(swapIndex);
   if (!swap) {  // Return if cannot swap in that direction.
     return;
   }
-  // Save currently loaded category.
-  this.model.saveCategoryEntry(curr, this.toolboxWorkspace);
-  // Swap curr and swap categories.
-  this.performSwap(curr, swap);
+  // Move currently selected category to index of other category.
+  // Indexes must be valid because confirmed that curr and swap exist.
+  this.moveCategoryToIndex(curr, swapIndex, currIndex);
   // Update category editing buttons.
-  this.view.updateState(this.model.getIndexByCategoryId
-      (this.model.getSelectedId()));
+  this.view.updateState(swapIndex);
 };
 
 /**
- * Given two categories, swaps them visually and in the model.
+ * Moves a category to a specified index and updates the model and view
+ * accordingly. Helper functions throw an error if indexes are out of bounds.
  *
- * @param {Category} category1 The first category to swap.
- * @param {Category} category2 The second category to swap
+ * @param {!Category} category The category to move.
+ * @param {int} newIndex The index to insert the category at.
+ * @param {int} oldIndex The index the category is currently at.
  */
-FactoryController.prototype.performSwap = function(curr, swap) {
-  // Get indexes of categories.
-  var currIndex = this.model.getIndexByCategoryId(curr.id);
-  var swapIndex = this.model.getIndexByCategoryId(swap.id)
-  // Visually swap category labels.
-  this.view.swapCategories(curr, swap, currIndex, swapIndex);
-  // Swap model information about categories, swap model.
-  this.model.swapCategoryOrder(curr, swap);
-}
+FactoryController.prototype.moveCategoryToIndex = function(category, newIndex,
+    oldIndex) {
+  this.model.moveInCategoryList(category, newIndex, oldIndex);
+  this.view.moveTabToLocation(category.id, newIndex, oldIndex);
+};

--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -331,6 +331,6 @@ FactoryController.prototype.moveCategory = function(offset) {
  */
 FactoryController.prototype.moveCategoryToIndex = function(category, newIndex,
     oldIndex) {
-  this.model.moveInCategoryList(category, newIndex, oldIndex);
-  this.view.moveTabToLocation(category.id, newIndex, oldIndex);
+  this.model.moveCategoryToIndex(category, newIndex, oldIndex);
+  this.view.moveTabToIndex(category.id, newIndex, oldIndex);
 };

--- a/demos/workspacefactory/factory_model.js
+++ b/demos/workspacefactory/factory_model.js
@@ -92,20 +92,6 @@ FactoryModel.prototype.changeCategoryName = function (newName, category) {
 };
 
 /**
- * Swaps the order of two categories in the category list.
- *
- * @param {Category} category1 First category to be swapped.
- * @param {Category} category2 Second category to be swapped.
- */
-FactoryModel.prototype.swapCategoryOrder = function(category1, category2) {
-  var index1 = this.getIndexByCategoryId(category1.id);
-  var index2 = this.getIndexByCategoryId(category2.id);
-  var temp = this.categoryList[index1];
-  this.categoryList[index1] = this.categoryList[index2];
-  this.categoryList[index2] = temp;
-};
-
-/**
  * Moves a category to a certain position in categoryList by removing it
  * and then inserting it at the correct index. Checks that indexes are in
  * bounds (throws error if not), but assumes that oldIndex is the correct index
@@ -115,7 +101,7 @@ FactoryModel.prototype.swapCategoryOrder = function(category1, category2) {
  * @param {int} newIndex The index to insert the category at.
  * @param {int} oldIndex The index the category is currently at.
  */
-FactoryModel.prototype.moveInCategoryList = function(category, newIndex,
+FactoryModel.prototype.moveCategoryToIndex = function(category, newIndex,
     oldIndex) {
   // Check that indexes are in bounds.
   if (newIndex < 0 || newIndex >= this.categoryList.length || oldIndex < 0 ||

--- a/demos/workspacefactory/factory_model.js
+++ b/demos/workspacefactory/factory_model.js
@@ -106,6 +106,27 @@ FactoryModel.prototype.swapCategoryOrder = function(category1, category2) {
 };
 
 /**
+ * Moves a category to a certain position in categoryList by removing it
+ * and then inserting it at the correct index. Checks that indexes are in
+ * bounds (throws error if not), but assumes that oldIndex is the correct index
+ * for category.
+ *
+ * @param {!Category} category The category to move in categoryList.
+ * @param {int} newIndex The index to insert the category at.
+ * @param {int} oldIndex The index the category is currently at.
+ */
+FactoryModel.prototype.moveInCategoryList = function(category, newIndex,
+    oldIndex) {
+  // Check that indexes are in bounds.
+  if (newIndex < 0 || newIndex >= this.categoryList.length || oldIndex < 0 ||
+      oldIndex >= this.categoryList.length) {
+    throw new Error('Index out of bounds');
+  }
+  this.deleteCategoryEntry(oldIndex);
+  this.categoryList.splice(newIndex, 0, category);
+}
+
+/**
  * Returns the ID of the currently selected category. Returns null if there are
  * no categories (if selected == null).
  *

--- a/demos/workspacefactory/factory_view.js
+++ b/demos/workspacefactory/factory_view.js
@@ -158,26 +158,6 @@ FactoryView.prototype.updateCategoryName = function(newName, id) {
 };
 
 /**
- * Given the two tabs to be swapped and the indexes of those tabs, swaps
- * them.
- *
- * @param {Category} curr Category currently selected.
- * @param {Category} swap Category to be swapped with.
- * @param {int} currIndex Index of category currently selected.
- * @param {int} swapIndex Index of category to be swapped with.
- */
-FactoryView.prototype.swapCategories = function(curr, swap,
-    currIndex, swapIndex) {
-  // Find tabs to swap.
-  var currTab = this.tabMap[curr.id];
-  var swapTab = this.tabMap[swap.id];
-  var table = document.getElementById('categoryTable');
-  // Swap tabs.
-  table.rows[currIndex].appendChild(swapTab);
-  table.rows[swapIndex].appendChild(currTab);
-};
-
-/**
  * Moves a tab from one index to another. Adjusts index inserting before
  * based on if inserting before or after. Checks that the indexes are in
  * bounds, throws error if not.
@@ -186,7 +166,7 @@ FactoryView.prototype.swapCategories = function(curr, swap,
  * @param {int} newIndex The index to move the category to.
  * @param {int} oldIndex The index the category is currently at.
  */
-FactoryView.prototype.moveTabToLocation = function(id, newIndex, oldIndex) {
+FactoryView.prototype.moveTabToIndex = function(id, newIndex, oldIndex) {
   var table = document.getElementById('categoryTable');
   // Check that indexes are in bounds
   if (newIndex < 0 || newIndex >= table.rows.length || oldIndex < 0 ||

--- a/demos/workspacefactory/factory_view.js
+++ b/demos/workspacefactory/factory_view.js
@@ -176,3 +176,30 @@ FactoryView.prototype.swapCategories = function(curr, swap,
   table.rows[currIndex].appendChild(swapTab);
   table.rows[swapIndex].appendChild(currTab);
 };
+
+/**
+ * Moves a tab from one index to another. Adjusts index inserting before
+ * based on if inserting before or after. Checks that the indexes are in
+ * bounds, throws error if not.
+ *
+ * @param {int} id The ID of the category to move.
+ * @param {int} newIndex The index to move the category to.
+ * @param {int} oldIndex The index the category is currently at.
+ */
+FactoryView.prototype.moveTabToLocation = function(id, newIndex, oldIndex) {
+  var table = document.getElementById('categoryTable');
+  // Check that indexes are in bounds
+  if (newIndex < 0 || newIndex >= table.rows.length || oldIndex < 0 ||
+      oldIndex >= table.rows.length) {
+    throw new Error('Index out of bounds');
+  }
+  if (newIndex < oldIndex) {  // Inserting before.
+    var row = table.insertRow(newIndex);
+    row.appendChild(this.tabMap[id]);
+    table.deleteRow(oldIndex + 1);
+  } else {  // Inserting after.
+    var row = table.insertRow(newIndex + 1);
+    row.appendChild(this.tabMap[id]);
+    table.deleteRow(oldIndex);
+  }
+};


### PR DESCRIPTION
Changed the implementation of moveCategory to move a category to a specific index (instead of just swapping categories). Changes made to factory_controller.js, factory_model.js, and factory_view.js. No new features added, but changing how categories are swapped allows for more flexibility later in development.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/23)

<!-- Reviewable:end -->
