### PR TITLE
Workspace Factory #5: Import Categories, Dropdown UI

### DIFF
--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -379,16 +379,19 @@ FactoryController.prototype.loadCategory = function() {
       return;   // Exit if cancelled.
     }
   } while (!this.isStandardCategoryName(name));
+
   // Create an empty category in the model and view.
-  this.createCategory(name, this.model.getSelected() == null);
-  var id = this.model.getCategoryIdByName(name);
-  // Load attributes of standard category.
-  this.model.loadStandardCategory(id, name);
+  var standardCategory = this.standardCategories[name.toLowerCase()]
+  this.createCategory(standardCategory.name, this.model.getSelected() == null);
+  var id = this.model.getCategoryIdByName(standardCategory.name);
+  var newCategory = this.model.getCategoryById(id);
+  // Copy attributes of standard category to new category in the model.
+  this.model.copyCategory(newCategory, standardCategory);
   // Color the category tab in the view.
-  if (!this.model.getCategoryById(id).color) {
-    throw new Error("No color in pre-built category.");
+  if (!newCategory.color) {
+    throw new Error("No color in standard category.");
   }
-  this.view.setBorderColor(id, this.model.getCategoryById(id).color);
+  this.view.setBorderColor(id, newCategory.color);
   // Switch to loaded category.
   this.switchCategory(id);
   // Update preview.
@@ -404,7 +407,7 @@ FactoryController.prototype.loadCategory = function() {
  * @return {boolean} True if name is a standard category name, false otherwise.
  */
 FactoryController.prototype.isStandardCategoryName = function(name) {
-  for (var category in standardCategories) {
+  for (var category in this.standardCategories) {
     if (name.toLowerCase() == category) {
       return true;
     }

--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -2,7 +2,7 @@
  * @fileoverview Contains the controller code for workspace factory. Depends
  * on the model and view objects (created as internal variables) and interacts
  * with previewWorkspace and toolboxWorkspace (internal references stored to
- * both). Also depends on prebuilt_categories.js for standard Blockly
+ * both). Also depends on standard_categories.js for standard Blockly
  * categories. Provides the functionality for the actions the user can initiate:
  * - adding and removing categories
  * - switching between categories

--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -231,12 +231,13 @@ FactoryController.prototype.printConfig = function() {
  * from no categories to categories or categories to no categories, reinjects
  * Blockly with reinjectPreview, otherwise just updates without reinjecting.
  * Called whenever a category is created, removed, or modified and when
- * "Update Preview" button is pressed.
- *
- * TODO(evd2014): Call updatePreview for Blockly Events. Figure out why
- * getting overwhelmed with create and delete events on category creation.
+ * Blockly move and delete events are fired. Do not call on create events
+ * or disabling will cause the user to "drop" their current blocks.
  */
 FactoryController.prototype.updatePreview = function() {
+  // Disable events to stop updatePreview from recursively calling itself
+  // through event handlers.
+  Blockly.Events.disable();
   var tree = Blockly.Options.parseToolboxTree
       (this.generator.generateConfigXml());
   // No categories, creates a simple flyout.
@@ -254,6 +255,8 @@ FactoryController.prototype.updatePreview = function() {
       this.previewWorkspace.toolbox_.populate_(tree);
     }
   }
+  // Reenable events.
+  Blockly.Events.enable();
 };
 
 /**

--- a/demos/workspacefactory/factory_generator.js
+++ b/demos/workspacefactory/factory_generator.js
@@ -74,6 +74,10 @@ FactoryGenerator.prototype.generateConfigXml = function() {
       if (category.color != null) {
         categoryElement.setAttribute('colour', category.color);
       }
+      // Add a custom attribute if one exists.
+      if (category.custom != null) {
+        categoryElement.setAttribute('custom', category.custom);
+      }
       // Load that category to workspace.
       this.toolboxWorkspace.clear();
       Blockly.Xml.domToWorkspace(category.xml, this.toolboxWorkspace);

--- a/demos/workspacefactory/factory_generator.js
+++ b/demos/workspacefactory/factory_generator.js
@@ -50,8 +50,7 @@ FactoryGenerator.prototype.generateConfigXml = function() {
       });
   // If no categories, use XML directly from workspace
   if (!this.model.hasCategories()) {
-    this.categoryWorkspaceToDom(xmlDom,
-        toolboxWorkspace.getTopBlocks());
+    this.categoryWorkspaceToDom(xmlDom, this.toolboxWorkspace.getTopBlocks());
   }
   else {
     // Assert that selected != null

--- a/demos/workspacefactory/factory_generator.js
+++ b/demos/workspacefactory/factory_generator.js
@@ -24,7 +24,7 @@ FactoryGenerator = function(model, toolboxWorkspace) {
  * @param {!Array.<!Blockly.Block>} topBlocks top level blocks to add to xmlDom
  */
 FactoryGenerator.prototype.categoryWorkspaceToDom = function(xmlDom, blocks) {
-  for (var i  =0, block; block = blocks[i]; i++) {
+  for (var i = 0, block; block = blocks[i]; i++) {
     var blockChild = Blockly.Xml.blockToDom(block);
     blockChild.removeAttribute('id');
     xmlDom.appendChild(blockChild);

--- a/demos/workspacefactory/factory_model.js
+++ b/demos/workspacefactory/factory_model.js
@@ -3,7 +3,6 @@
  * in workspace factory. Each category has a name, XML to load that category,
  * and a unique ID making it possible to change category names and move
  * categories easily. Also keeps track of the currently selected category.
- * Depends on standard_categories.js for standard Blockly categories. .
  *
  * @author Emma Dauterman (evd2014)
  */
@@ -245,21 +244,23 @@ FactoryModel.prototype.setCategoryColorById = function (id, color) {
 };
 
 /**
- * Sets the attributes of a category based on a stadard category given the
- * id of the category to update and the name of the standard category
- * (case insensitive).
+ * Given two categories, copies everything from the original to the copy except
+ * for the ID (which must stay unique between categories). Throws an error
+ * if either the original category or the category to be copied into are null.
  *
- * @param {!string} id The ID of the category to update.
- * @param {!string} name The name of the standard category to load.
+ * @param {!Category} copy The category that should be changed to mirror
+ * original.
+ * @param {!Category} original The category that should be copied into copy.
  */
-FactoryModel.prototype.loadStandardCategory = function(id, name) {
-  var category = this.getCategoryById(id);
-  if (!standardCategories[name.toLowerCase()]) {
-    throw new Error('Trying to load category that does not exist.');
+FactoryModel.prototype.copyCategory = function(copy, original) {
+  if (!copy || !original) {
+    throw new Error('Trying to copy null category.');
   }
-  category.xml = standardCategories[name.toLowerCase()].xml;
-  category.color = standardCategories[name.toLowerCase()].color;
-  category.custom = standardCategories[name.toLowerCase()].custom;
+  // Copy all attributes except ID.
+  copy.xml = original.xml;
+  copy.color = original.color;
+  copy.custom = original.custom;
+  copy.name = original.name;
 };
 
 /**

--- a/demos/workspacefactory/factory_model.js
+++ b/demos/workspacefactory/factory_model.js
@@ -244,23 +244,25 @@ FactoryModel.prototype.setCategoryColorById = function (id, color) {
 };
 
 /**
- * Given two categories, copies everything from the original to the copy except
- * for the ID (which must stay unique between categories). Throws an error
- * if either the original category or the category to be copied into are null.
+ * Makes a copy of the original category, adds it to the categoryList, and
+ * returns it. Everything about the copy is identical except for its ID. Throws
+ * an error if the original category is null.
  *
- * @param {!Category} copy The category that should be changed to mirror
- * original.
- * @param {!Category} original The category that should be copied into copy.
+ * @param {!Category} original The category that should be copied.
+ * @return {!Category} The copy of original.
  */
-FactoryModel.prototype.copyCategory = function(copy, original) {
-  if (!copy || !original) {
+FactoryModel.prototype.copyCategory = function(original) {
+  if (!original) {
     throw new Error('Trying to copy null category.');
   }
+  copy = new Category(original.name);
   // Copy all attributes except ID.
   copy.xml = original.xml;
   copy.color = original.color;
   copy.custom = original.custom;
-  copy.name = original.name;
+  // Add copy to the category list and return it.
+  this.categoryList.push(copy);
+  return copy;
 };
 
 /**

--- a/demos/workspacefactory/factory_model.js
+++ b/demos/workspacefactory/factory_model.js
@@ -3,6 +3,7 @@
  * in workspace factory. Each category has a name, XML to load that category,
  * and a unique ID making it possible to change category names and move
  * categories easily. Also keeps track of the currently selected category.
+ * Depends on standard_categories.js for standard Blockly categories. .
  *
  * @author Emma Dauterman (evd2014)
  */
@@ -241,7 +242,25 @@ FactoryModel.prototype.getCategoryIdByName = function(name) {
 FactoryModel.prototype.setCategoryColorById = function (id, color) {
   var category = this.getCategoryById(id);
   category.color = color;
-}
+};
+
+/**
+ * Sets the attributes of a category based on a stadard category given the
+ * id of the category to update and the name of the standard category
+ * (case insensitive).
+ *
+ * @param {!string} id The ID of the category to update.
+ * @param {!string} name The name of the standard category to load.
+ */
+FactoryModel.prototype.loadStandardCategory = function(id, name) {
+  var category = this.getCategoryById(id);
+  if (!standardCategories[name.toLowerCase()]) {
+    throw new Error('Trying to load category that does not exist.');
+  }
+  category.xml = standardCategories[name.toLowerCase()].xml;
+  category.color = standardCategories[name.toLowerCase()].color;
+  category.custom = standardCategories[name.toLowerCase()].custom;
+};
 
 /**
  * Class for a Category
@@ -256,4 +275,6 @@ Category = function(name) {
   this.id = Blockly.genUid();
   // Color of category. Default is no color.
   this.color = null;
+  // Stores a custom tag, if necessary. Null if no custom tag.
+  this.custom = null;
 };

--- a/demos/workspacefactory/factory_view.js
+++ b/demos/workspacefactory/factory_view.js
@@ -77,7 +77,7 @@ FactoryView.prototype.deleteCategoryRow = function(id, index) {
  * @param {int} selectedIndex The index of the currently selected category.
  */
 FactoryView.prototype.updateState = function(selectedIndex) {
-  document.getElementById('button_name').disabled = selectedIndex < 0;
+  document.getElementById('button_edit').disabled = selectedIndex < 0;
   document.getElementById('button_color').disabled = selectedIndex < 0;
   document.getElementById('button_up').disabled =
       selectedIndex == 0 ? true : false;

--- a/demos/workspacefactory/factory_view.js
+++ b/demos/workspacefactory/factory_view.js
@@ -78,7 +78,6 @@ FactoryView.prototype.deleteCategoryRow = function(id, index) {
  */
 FactoryView.prototype.updateState = function(selectedIndex) {
   document.getElementById('button_edit').disabled = selectedIndex < 0;
-  document.getElementById('button_color').disabled = selectedIndex < 0;
   document.getElementById('button_up').disabled =
       selectedIndex == 0 ? true : false;
   var table = document.getElementById('categoryTable');

--- a/demos/workspacefactory/factory_view.js
+++ b/demos/workspacefactory/factory_view.js
@@ -78,11 +78,12 @@ FactoryView.prototype.deleteCategoryRow = function(id, index) {
  */
 FactoryView.prototype.updateState = function(selectedIndex) {
   document.getElementById('button_edit').disabled = selectedIndex < 0;
+  document.getElementById('button_remove').disabled = selectedIndex < 0;
   document.getElementById('button_up').disabled =
-      selectedIndex == 0 ? true : false;
+      selectedIndex <= 0 ? true : false;
   var table = document.getElementById('categoryTable');
-  document.getElementById('button_down').disabled =
-      selectedIndex == table.rows.length - 1 ? true : false;
+  document.getElementById('button_down').disabled = selectedIndex >=
+      table.rows.length - 1 || selectedIndex < 0 ? true : false;
 };
 
 /**

--- a/demos/workspacefactory/index.html
+++ b/demos/workspacefactory/index.html
@@ -9,6 +9,7 @@
 <script src="factory_controller.js"></script>
 <script src="factory_view.js"></script>
 <script src="factory_generator.js"></script>
+<script src="standard_categories.js"></script>
 <script src="../../../closure-library/closure/goog/base.js"></script>
 <link rel="stylesheet" href="style.css">
 
@@ -47,18 +48,24 @@ goog.require('goog.ui.ColorPicker');
       <td id="tab_help">Your categories will appear here</td>
     </table>
     <p>&nbsp;</p>
+    <div class='dropdown'>
     <button id="button_add">+</button>
+    <div id="dropdown_add" class="dropdown-content">
+      <a id='dropdown_newCategory'>New Category</a>
+      <a id='dropdown_loadCategory'>Pre-existing Category</a>
+    </div>
+    </div>
     <button id="button_remove">-</button>
-    <button id="button_up">&#8593;</button>
-    <button id="button_down">&#8595;</button>
     <p>&nbsp;</p>
     <div class='dropdown'>
     <button id="button_edit">Edit</button>
     <div id="dropdown_edit" class="dropdown-content">
-      <a href='#' id='dropdown_name'>Name</a>
-      <a href='#' id='dropdown_color'>Color</a>
+      <a id='dropdown_name'>Name</a>
+      <a id='dropdown_color'>Color</a>
     </div>
     </div>
+    <button id="button_up">&#8593;</button>
+    <button id="button_down">&#8595;</button>
   </aside>
 </section>
 
@@ -463,7 +470,15 @@ goog.require('goog.ui.ColorPicker');
 
   // Wrappers to attach buttons to method calls for the controller object
   var addWrapper = function() {
+    document.getElementById('dropdown_add').classList.toggle("show");
+  };
+  var newCategoryWrapper = function() {
     controller.addCategory();
+    document.getElementById('dropdown_add').classList.toggle("show");
+  };
+  var loadCategoryWrapper = function() {
+    controller.loadCategory();
+    document.getElementById('dropdown_add').classList.toggle("show");
   };
   var removeWrapper = function() {
     controller.removeCategory();
@@ -490,8 +505,13 @@ goog.require('goog.ui.ColorPicker');
     controller.changeName();
     document.getElementById('dropdown_edit').classList.toggle("show");
   };
+
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
+  document.getElementById('dropdown_newCategory').addEventListener
+      ('click', newCategoryWrapper);
+  document.getElementById('dropdown_loadCategory').addEventListener
+      ('click', loadCategoryWrapper);
   document.getElementById('button_remove').addEventListener
       ('click', removeWrapper);
   document.getElementById('button_export').addEventListener
@@ -508,6 +528,7 @@ goog.require('goog.ui.ColorPicker');
       ('click', editWrapper);
   document.getElementById('dropdown_name').addEventListener
       ('click', nameWrapper);
+
   // Create color picker with specific set of Blockly colors.
   var colorPicker = new goog.ui.ColorPicker();
   colorPicker.setColors(colors);
@@ -520,9 +541,12 @@ goog.require('goog.ui.ColorPicker');
         controller.changeSelectedCategoryColor(popupPicker.getSelectedColor());
         document.getElementById('dropdown_edit').classList.toggle("show");
       });
-
+  // Disable category editing buttons until categories are created.
+  document.getElementById('button_remove').disabled = true;
   document.getElementById('button_edit').disabled = true;
   document.getElementById('button_up').disabled = true;
   document.getElementById('button_down').disabled = true;
+  // TODO(evd2014): Listen for Blockly events to update preview, figure out
+  // why getting overwhelmed with create/delete events when changing categories.
 </script>
 </html>

--- a/demos/workspacefactory/index.html
+++ b/demos/workspacefactory/index.html
@@ -52,7 +52,7 @@ goog.require('goog.ui.ColorPicker');
     <button id="button_add">+</button>
     <div id="dropdown_add" class="dropdown-content">
       <a id='dropdown_newCategory'>New Category</a>
-      <a id='dropdown_loadCategory'>Pre-existing Category</a>
+      <a id='dropdown_loadCategory'>Standard Category</a>
     </div>
     </div>
     <button id="button_remove">-</button>

--- a/demos/workspacefactory/index.html
+++ b/demos/workspacefactory/index.html
@@ -52,8 +52,13 @@ goog.require('goog.ui.ColorPicker');
     <button id="button_up">&#8593;</button>
     <button id="button_down">&#8595;</button>
     <p>&nbsp;</p>
-    <button id="button_name">Edit</button>
-    <button id="button_color">Color</button>
+    <div class='dropdown'>
+    <button id="button_edit">Edit</button>
+    <div id="dropdown_edit" class="dropdown-content">
+      <a href='#' id='dropdown_name'>Name</a>
+      <a href='#' id='dropdown_color'>Color</a>
+    </div>
+    </div>
   </aside>
 </section>
 
@@ -472,14 +477,18 @@ goog.require('goog.ui.ColorPicker');
   var previewWrapper = function() {
     controller.updatePreview();
   };
-  var nameWrapper = function() {
-    controller.changeName();
-  };
   var upWrapper = function() {
     controller.moveCategory(-1);
   };
   var downWrapper = function() {
     controller.moveCategory(1);
+  };
+  var editWrapper = function() {
+    document.getElementById('dropdown_edit').classList.toggle("show");
+  };
+  var nameWrapper = function() {
+    controller.changeName();
+    document.getElementById('dropdown_edit').classList.toggle("show");
   };
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -491,27 +500,29 @@ goog.require('goog.ui.ColorPicker');
       ('click', printWrapper);
   document.getElementById('button_preview').addEventListener
       ('click', previewWrapper);
-  document.getElementById('button_name').addEventListener
-      ('click', nameWrapper);
   document.getElementById('button_up').addEventListener
       ('click', upWrapper);
   document.getElementById('button_down').addEventListener
       ('click', downWrapper);
+  document.getElementById('button_edit').addEventListener
+      ('click', editWrapper);
+  document.getElementById('dropdown_name').addEventListener
+      ('click', nameWrapper);
   // Create color picker with specific set of Blockly colors.
   var colorPicker = new goog.ui.ColorPicker();
   colorPicker.setColors(colors);
   // Create and render the popup color picker and attach to button.
   var popupPicker = new goog.ui.PopupColorPicker(null, colorPicker);
   popupPicker.render();
-  popupPicker.attach(document.getElementById('button_color'));
+  popupPicker.attach(document.getElementById('dropdown_color'));
   popupPicker.setFocusable(true);
   goog.events.listen(popupPicker, 'change', function(e) {
         controller.changeSelectedCategoryColor(popupPicker.getSelectedColor());
+        document.getElementById('dropdown_edit').classList.toggle("show");
       });
 
-  document.getElementById('button_name').disabled = true;
+  document.getElementById('button_edit').disabled = true;
   document.getElementById('button_up').disabled = true;
   document.getElementById('button_down').disabled = true;
-  document.getElementById('button_color').disabled = true;
 </script>
 </html>

--- a/demos/workspacefactory/index.html
+++ b/demos/workspacefactory/index.html
@@ -541,6 +541,9 @@ goog.require('goog.ui.ColorPicker');
   document.getElementById('button_up').disabled = true;
   document.getElementById('button_down').disabled = true;
   // Listen for Blockly move and delete events to update preview.
+  // Not listening for Blockly create events because causes the user to drop blocks
+  // when dragging them into workspace. Could cause problems if ever load blocks into
+  // workspace directly without calling updatePreview.
   toolboxWorkspace.addChangeListener(function(e) {
     if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
       controller.updatePreview();

--- a/demos/workspacefactory/index.html
+++ b/demos/workspacefactory/index.html
@@ -541,9 +541,9 @@ goog.require('goog.ui.ColorPicker');
   document.getElementById('button_up').disabled = true;
   document.getElementById('button_down').disabled = true;
   // Listen for Blockly move and delete events to update preview.
-  // Not listening for Blockly create events because causes the user to drop blocks
-  // when dragging them into workspace. Could cause problems if ever load blocks into
-  // workspace directly without calling updatePreview.
+  // Not listening for Blockly create events because causes the user to drop
+  // blocks when dragging them into workspace. Could cause problems if ever load
+  // blocks into workspace directly without calling updatePreview.
   toolboxWorkspace.addChangeListener(function(e) {
     if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
       controller.updatePreview();

--- a/demos/workspacefactory/index.html
+++ b/demos/workspacefactory/index.html
@@ -473,11 +473,11 @@ goog.require('goog.ui.ColorPicker');
   };
   var newCategoryWrapper = function() {
     controller.addCategory();
-    document.getElementById('dropdown_add').classList.toggle("show");
+    document.getElementById('dropdown_add').classList.remove("show");
   };
   var loadCategoryWrapper = function() {
     controller.loadCategory();
-    document.getElementById('dropdown_add').classList.toggle("show");
+    document.getElementById('dropdown_add').classList.remove("show");
   };
   var removeWrapper = function() {
     controller.removeCategory();
@@ -499,7 +499,7 @@ goog.require('goog.ui.ColorPicker');
   };
   var nameWrapper = function() {
     controller.changeName();
-    document.getElementById('dropdown_edit').classList.toggle("show");
+    document.getElementById('dropdown_edit').classList.remove("show");
   };
 
   document.getElementById('button_add').addEventListener
@@ -533,7 +533,7 @@ goog.require('goog.ui.ColorPicker');
   popupPicker.setFocusable(true);
   goog.events.listen(popupPicker, 'change', function(e) {
         controller.changeSelectedCategoryColor(popupPicker.getSelectedColor());
-        document.getElementById('dropdown_edit').classList.toggle("show");
+        document.getElementById('dropdown_edit').classList.remove("show");
       });
   // Disable category editing buttons until categories are created.
   document.getElementById('button_remove').disabled = true;

--- a/demos/workspacefactory/index.html
+++ b/demos/workspacefactory/index.html
@@ -32,7 +32,6 @@ goog.require('goog.ui.ColorPicker');
       <p>
         <button id="button_export">Export Config</button>
         <button id="button_print">Print Config</button>
-        <button id="button_preview">Update Preview</button>
       </p>
     </td>
   </tr>
@@ -489,9 +488,6 @@ goog.require('goog.ui.ColorPicker');
   var printWrapper = function() {
     controller.printConfig();
   };
-  var previewWrapper = function() {
-    controller.updatePreview();
-  };
   var upWrapper = function() {
     controller.moveCategory(-1);
   };
@@ -518,8 +514,6 @@ goog.require('goog.ui.ColorPicker');
       ('click', exportWrapper);
   document.getElementById('button_print').addEventListener
       ('click', printWrapper);
-  document.getElementById('button_preview').addEventListener
-      ('click', previewWrapper);
   document.getElementById('button_up').addEventListener
       ('click', upWrapper);
   document.getElementById('button_down').addEventListener
@@ -546,7 +540,11 @@ goog.require('goog.ui.ColorPicker');
   document.getElementById('button_edit').disabled = true;
   document.getElementById('button_up').disabled = true;
   document.getElementById('button_down').disabled = true;
-  // TODO(evd2014): Listen for Blockly events to update preview, figure out
-  // why getting overwhelmed with create/delete events when changing categories.
+  // Listen for Blockly move and delete events to update preview.
+  toolboxWorkspace.addChangeListener(function(e) {
+    if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
+      controller.updatePreview();
+    }
+  });
 </script>
 </html>

--- a/demos/workspacefactory/standard_categories.js
+++ b/demos/workspacefactory/standard_categories.js
@@ -1,0 +1,359 @@
+/**
+ * @fileoverview Contains a map of standard Blockly categories used to load
+ * standard Blockly categories into the user's toolbox. The map is keyed by
+ * the lower case name of the category, and contains the XML DOM element, the
+ * color (CSS string), and any custom tags (null if there are no custom tags).
+ *
+ * @author Emma Dauterman (evd2014)
+ */
+
+var standardCategories = Object.create(null);
+
+standardCategories['logic'] = {
+      xml: Blockly.Xml.textToDom(
+          '<xml>' +
+          '<block type="controls_if" x="13" y="13"></block>' +
+          '<block type="logic_compare" x="13" y="88"></block>' +
+          '<block type="logic_operation" x="13" y="138"></block>' +
+          '<block type="logic_negate" x="13" y="188"></block>' +
+          '<block type="logic_boolean" x="13" y="238"></block>' +
+          '<block type="logic_null" x="13" y="288"></block>' +
+          '<block type="logic_ternary" x="13" y="338"></block>' +
+          '</xml>'),
+      color: '#5C81A6',
+      custom: null
+    };
+
+standardCategories['loops'] = {
+      xml: Blockly.Xml.textToDom(
+          '<xml>' +
+          '<block type="controls_repeat_ext" x="13" y="13">' +
+            '<value name="TIMES">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">10</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="controls_whileUntil" x="12" y="113"></block>' +
+          '<block type="controls_for" x="12" y="213">' +
+            '<value name="FROM">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">1</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="TO">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">10</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="BY">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">1</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="controls_forEach" x="12" y="313"></block>' +
+          '<block type="controls_flow_statements" x="12" y="413"></block>' +
+          '</xml>'),
+      color: '#5CA65C',
+      custom: null
+    };
+
+standardCategories['math'] = {
+      xml: Blockly.Xml.textToDom(
+          '<xml>' +
+          '<block type="math_number" x="13" y="13"></block>' +
+          '<block type="math_arithmetic" x="13" y="63">' +
+            '<value name="A">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">1</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="B">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">1</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="math_single" x="13" y="113">' +
+            '<value name="NUM">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">9</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="math_trig" x="13" y="163">' +
+            '<value name="NUM">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">45</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="math_constant" x="13" y="213"></block>' +
+          '<block type="math_number_property" x="13" y="263">' +
+            '<value name="NUMBER_TO_CHECK">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">0</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="math_change" x="13" y="313">' +
+            '<value name="DELTA">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">1</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="math_round" x="13" y="363">' +
+            '<value name="NUM">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">3.1</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="math_on_list" x="13" y="413"></block>' +
+          '<block type="math_modulo" x="13" y="463">' +
+            '<value name="DIVIDEND">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">64</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="DIVISOR">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">10</field>'+
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="math_constrain" x="13" y="512">' +
+            '<value name="VALUE">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">50</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="LOW">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">1</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="HIGH">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">100</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="math_random_int" x="13" y="562">' +
+            '<value name="FROM">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">1</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="TO">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">100</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="math_random_float" x="13" y="612"></block>' +
+          '</xml>'),
+      color: '#5C68A6',
+      custom: null
+    };
+
+standardCategories['text'] = {
+      xml: Blockly.Xml.textToDom(
+          '<xml>' +
+          '<block type="text" x="13" y="13"></block>' +
+          '<block type="text_join" x="13" y="63"></block>' +
+          '<block type="text_append" x="13" y="138">' +
+            '<value name="TEXT">' +
+              '<shadow type="text"></shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="text_length" x="13" y="188">' +
+            '<value name="VALUE">' +
+              '<shadow type="text">' +
+                '<field name="TEXT">abc</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="text_isEmpty" x="13" y="238">' +
+            '<value name="VALUE">' +
+              '<shadow type="text">' +
+                '<field name="TEXT"></field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="text_indexOf" x="13" y="288">' +
+            '<value name="VALUE">' +
+              '<block type="variables_get">' +
+                '<field name="VAR">text</field>' +
+              '</block>' +
+            '</value>' +
+            '<value name="FIND">' +
+              '<shadow type="text">' +
+                '<field name="TEXT">abc</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="text_charAt" x="13" y="337">' +
+            '<value name="VALUE">' +
+              '<block type="variables_get">' +
+                '<field name="VAR">text</field>' +
+              '</block>' +
+            '</value>' +
+          '</block>' +
+          '<block type="text_getSubstring" x="13" y="387">' +
+            '<value name="STRING">' +
+              '<block type="variables_get">' +
+                '<field name="VAR">text</field>' +
+              '</block>' +
+            '</value>' +
+          '</block>' +
+          '<block type="text_changeCase" x="13" y="437">' +
+            '<value name="TEXT">' +
+              '<shadow type="text">' +
+                '<field name="TEXT">abc</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="text_trim" x="13" y="488">' +
+            '<value name="TEXT">' +
+              '<shadow type="text">' +
+                '<field name="TEXT">abc</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="text_print" x="13" y="538">' +
+            '<value name="TEXT">' +
+              '<shadow type="text">' +
+                '<field name="TEXT">abc</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="text_prompt_ext" x="13" y="588">' +
+            '<value name="TEXT">' +
+              '<shadow type="text">' +
+                '<field name="TEXT">abc</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '</xml>'),
+      color: '#5CA68D',
+      custom: null
+    };
+
+standardCategories['lists'] = {
+      xml: Blockly.Xml.textToDom(
+          '<xml>' +
+          '<block type="lists_create_with" x="13" y="-187">' +
+            '<mutation items="0"></mutation>' +
+          '</block>' +
+          '<block type="lists_create_with"  x="13" y="-137"></block>' +
+          '<block type="lists_repeat" x="13" y="-37">' +
+            '<value name="NUM">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">5</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="lists_length" x="13" y="13" ></block>' +
+          '<block type="lists_isEmpty" x="13" y="63"></block>' +
+          '<block type="lists_indexOf" x="13" y="113">' +
+            '<value name="VALUE">' +
+              '<block type="variables_get">' +
+                '<field name="VAR">list</field>' +
+              '</block>' +
+            '</value>' +
+          '</block>' +
+          '<block type="lists_getIndex" x="13" y="162">' +
+            '<value name="VALUE">' +
+              '<block type="variables_get">' +
+                '<field name="VAR">list</field>' +
+              '</block>' +
+            '</value>' +
+          '</block>' +
+          '<block type="lists_setIndex" x="13" y="212">' +
+            '<value name="LIST">' +
+              '<block type="variables_get">' +
+                '<field name="VAR">list</field>' +
+              '</block>' +
+            '</value>' +
+          '</block>' +
+          '<block type="lists_getSublist" x="13" y="262">' +
+            '<value name="LIST">' +
+              '<block type="variables_get">' +
+                '<field name="VAR">list</field>' +
+              '</block>' +
+            '</value>' +
+          '</block>' +
+          '<block type="lists_split" x="13" y="312">' +
+            '<value name="DELIM">' +
+              '<shadow type="text">' +
+                '<field name="TEXT">,</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="lists_sort" x="13" y="362"></block>' +
+          '</xml>'),
+      color: '#745CA6',
+      custom: null
+    };
+
+standardCategories['colour'] = {
+      xml: Blockly.Xml.textToDom(
+          '<xml>' +
+          '<block type="colour_picker" x="13" y="13"></block>' +
+          '<block type="colour_random" x="13" y="63"></block>' +
+          '<block type="colour_rgb" x="13" y="113">' +
+            '<value name="RED">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">100</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="GREEN">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">50</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="BLUE">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">0</field>' +
+              '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '<block type="colour_blend" x="13" y="213">' +
+            '<value name="COLOUR1">' +
+              '<shadow type="colour_picker">' +
+                '<field name="COLOUR">#ff0000</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="COLOUR2">' +
+              '<shadow type="colour_picker">' +
+                '<field name="COLOUR">#3333ff</field>' +
+              '</shadow>' +
+            '</value>' +
+            '<value name="RATIO">' +
+              '<shadow type="math_number">' +
+                '<field name="NUM">0.5</field>' +
+             '</shadow>' +
+            '</value>' +
+          '</block>' +
+          '</xml>'),
+      color: '#A6745C',
+      custom: null
+    };
+standardCategories['variables'] = {
+      xml: Blockly.Xml.textToDom(
+          '<xml>' +
+          '</xml>'),
+      color: '#A65C81',
+      custom: 'VARIABLE'
+    };
+
+standardCategories['functions'] = {
+      xml: Blockly.Xml.textToDom(
+          '<xml>' +
+          '</xml>'),
+      color: '#9A5CA6',
+      custom: 'PROCEDURE'
+    };

--- a/demos/workspacefactory/standard_categories.js
+++ b/demos/workspacefactory/standard_categories.js
@@ -7,10 +7,11 @@
  * @author Emma Dauterman (evd2014)
  */
 
-FactoryController.standardCategories = Object.create(null);
+FactoryController.prototype.standardCategories = Object.create(null);
 
-FactoryController.standardCategories['logic'] = new Category('Logic');
-FactoryController.standardCategories['logic'].xml = Blockly.Xml.textToDom(
+FactoryController.prototype.standardCategories['logic'] = new Category('Logic');
+FactoryController.prototype.standardCategories['logic'].xml =
+    Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="controls_if" x="13" y="13"></block>' +
     '<block type="logic_compare" x="13" y="88"></block>' +
@@ -20,10 +21,11 @@ FactoryController.standardCategories['logic'].xml = Blockly.Xml.textToDom(
     '<block type="logic_null" x="13" y="288"></block>' +
     '<block type="logic_ternary" x="13" y="338"></block>' +
     '</xml>');
-FactoryController.standardCategories['logic'].color = '#5C81A6';
+FactoryController.prototype.standardCategories['logic'].color = '#5C81A6';
 
-FactoryController.standardCategories['loops'] = new Category('Loops');
-FactoryController.standardCategories['loops'].xml = Blockly.Xml.textToDom(
+FactoryController.prototype.standardCategories['loops'] = new Category('Loops');
+FactoryController.prototype.standardCategories['loops'].xml =
+    Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="controls_repeat_ext" x="13" y="13">' +
       '<value name="TIMES">' +
@@ -53,10 +55,11 @@ FactoryController.standardCategories['loops'].xml = Blockly.Xml.textToDom(
     '<block type="controls_forEach" x="12" y="313"></block>' +
     '<block type="controls_flow_statements" x="12" y="413"></block>' +
     '</xml>');
-FactoryController.standardCategories['loops'].color = '#5CA65C';
+FactoryController.prototype.standardCategories['loops'].color = '#5CA65C';
 
-FactoryController.standardCategories['math'] = new Category('Math');
-FactoryController.standardCategories['math'].xml = Blockly.Xml.textToDom(
+FactoryController.prototype.standardCategories['math'] = new Category('Math');
+FactoryController.prototype.standardCategories['math'].xml =
+    Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="math_number" x="13" y="13"></block>' +
     '<block type="math_arithmetic" x="13" y="63">' +
@@ -151,10 +154,11 @@ FactoryController.standardCategories['math'].xml = Blockly.Xml.textToDom(
     '</block>' +
     '<block type="math_random_float" x="13" y="612"></block>' +
     '</xml>');
-FactoryController.standardCategories['math'].color = '#5C68A6';
+FactoryController.prototype.standardCategories['math'].color = '#5C68A6';
 
-FactoryController.standardCategories['text'] = new Category('Text');
-FactoryController.standardCategories['text'].xml = Blockly.Xml.textToDom(
+FactoryController.prototype.standardCategories['text'] = new Category('Text');
+FactoryController.prototype.standardCategories['text'].xml =
+    Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="text" x="13" y="13"></block>' +
     '<block type="text_join" x="13" y="63"></block>' +
@@ -232,10 +236,11 @@ FactoryController.standardCategories['text'].xml = Blockly.Xml.textToDom(
       '</value>' +
     '</block>' +
     '</xml>');
-FactoryController.standardCategories['text'].color = '#5CA68D';
+FactoryController.prototype.standardCategories['text'].color = '#5CA68D';
 
-FactoryController.standardCategories['lists'] = new Category('Lists');
-FactoryController.standardCategories['lists'].xml = Blockly.Xml.textToDom(
+FactoryController.prototype.standardCategories['lists'] = new Category('Lists');
+FactoryController.prototype.standardCategories['lists'].xml =
+    Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="lists_create_with" x="13" y="-187">' +
       '<mutation items="0"></mutation>' +
@@ -287,11 +292,12 @@ FactoryController.standardCategories['lists'].xml = Blockly.Xml.textToDom(
     '</block>' +
     '<block type="lists_sort" x="13" y="362"></block>' +
     '</xml>');
-FactoryController.standardCategories['lists'].color = '#745CA6';
+FactoryController.prototype.standardCategories['lists'].color = '#745CA6';
 
-FactoryController.standardCategories['colour'] =
+FactoryController.prototype.standardCategories['colour'] =
     new Category('Colour');
-FactoryController.standardCategories['colour'].xml = Blockly.Xml.textToDom(
+FactoryController.prototype.standardCategories['colour'].xml =
+    Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="colour_picker" x="13" y="13"></block>' +
     '<block type="colour_random" x="13" y="63"></block>' +
@@ -330,15 +336,15 @@ FactoryController.standardCategories['colour'].xml = Blockly.Xml.textToDom(
       '</value>' +
     '</block>' +
     '</xml>');
-FactoryController.standardCategories['colour'].color = '#A6745C';
+FactoryController.prototype.standardCategories['colour'].color = '#A6745C';
 
-FactoryController.standardCategories['functions'] =
+FactoryController.prototype.standardCategories['functions'] =
     new Category('Functions');
-FactoryController.standardCategories['functions'].color = '#9A5CA6'
-FactoryController.standardCategories['functions'].custom =
+FactoryController.prototype.standardCategories['functions'].color = '#9A5CA6'
+FactoryController.prototype.standardCategories['functions'].custom =
     'PROCEDURE';
 
-FactoryController.standardCategories['variables'] =
+FactoryController.prototype.standardCategories['variables'] =
     new Category('Variables');
-FactoryController.standardCategories['variables'].color = '#A65C81';
-FactoryController.standardCategories['variables'].custom = 'VARIABLE';
+FactoryController.prototype.standardCategories['variables'].color = '#A65C81';
+FactoryController.prototype.standardCategories['variables'].custom = 'VARIABLE';

--- a/demos/workspacefactory/standard_categories.js
+++ b/demos/workspacefactory/standard_categories.js
@@ -1,359 +1,350 @@
 /**
  * @fileoverview Contains a map of standard Blockly categories used to load
  * standard Blockly categories into the user's toolbox. The map is keyed by
- * the lower case name of the category, and contains the XML DOM element, the
- * color (CSS string), and any custom tags (null if there are no custom tags).
+ * the lower case name of the category, and contains the Category object for
+ * that particular category.
  *
  * @author Emma Dauterman (evd2014)
  */
 
-var standardCategories = Object.create(null);
+FactoryController.prototype.standardCategories = Object.create(null);
 
-standardCategories['logic'] = {
-      xml: Blockly.Xml.textToDom(
-          '<xml>' +
-          '<block type="controls_if" x="13" y="13"></block>' +
-          '<block type="logic_compare" x="13" y="88"></block>' +
-          '<block type="logic_operation" x="13" y="138"></block>' +
-          '<block type="logic_negate" x="13" y="188"></block>' +
-          '<block type="logic_boolean" x="13" y="238"></block>' +
-          '<block type="logic_null" x="13" y="288"></block>' +
-          '<block type="logic_ternary" x="13" y="338"></block>' +
-          '</xml>'),
-      color: '#5C81A6',
-      custom: null
-    };
+FactoryController.prototype.standardCategories['logic'] = new Category('Logic');
+FactoryController.prototype.standardCategories['logic'].xml =
+    Blockly.Xml.textToDom(
+    '<xml>' +
+    '<block type="controls_if" x="13" y="13"></block>' +
+    '<block type="logic_compare" x="13" y="88"></block>' +
+    '<block type="logic_operation" x="13" y="138"></block>' +
+    '<block type="logic_negate" x="13" y="188"></block>' +
+    '<block type="logic_boolean" x="13" y="238"></block>' +
+    '<block type="logic_null" x="13" y="288"></block>' +
+    '<block type="logic_ternary" x="13" y="338"></block>' +
+    '</xml>');
+FactoryController.prototype.standardCategories['logic'].color = '#5C81A6';
 
-standardCategories['loops'] = {
-      xml: Blockly.Xml.textToDom(
-          '<xml>' +
-          '<block type="controls_repeat_ext" x="13" y="13">' +
-            '<value name="TIMES">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">10</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="controls_whileUntil" x="12" y="113"></block>' +
-          '<block type="controls_for" x="12" y="213">' +
-            '<value name="FROM">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">1</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="TO">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">10</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="BY">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">1</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="controls_forEach" x="12" y="313"></block>' +
-          '<block type="controls_flow_statements" x="12" y="413"></block>' +
-          '</xml>'),
-      color: '#5CA65C',
-      custom: null
-    };
+FactoryController.prototype.standardCategories['loops'] = new Category('Loops');
+FactoryController.prototype.standardCategories['loops'].xml =
+    Blockly.Xml.textToDom(
+    '<xml>' +
+    '<block type="controls_repeat_ext" x="13" y="13">' +
+      '<value name="TIMES">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="controls_whileUntil" x="12" y="113"></block>' +
+    '<block type="controls_for" x="12" y="213">' +
+      '<value name="FROM">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="TO">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="BY">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="controls_forEach" x="12" y="313"></block>' +
+    '<block type="controls_flow_statements" x="12" y="413"></block>' +
+    '</xml>');
+FactoryController.prototype.standardCategories['loops'].color = '#5CA65C';
 
-standardCategories['math'] = {
-      xml: Blockly.Xml.textToDom(
-          '<xml>' +
-          '<block type="math_number" x="13" y="13"></block>' +
-          '<block type="math_arithmetic" x="13" y="63">' +
-            '<value name="A">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">1</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="B">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">1</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="math_single" x="13" y="113">' +
-            '<value name="NUM">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">9</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="math_trig" x="13" y="163">' +
-            '<value name="NUM">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">45</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="math_constant" x="13" y="213"></block>' +
-          '<block type="math_number_property" x="13" y="263">' +
-            '<value name="NUMBER_TO_CHECK">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">0</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="math_change" x="13" y="313">' +
-            '<value name="DELTA">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">1</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="math_round" x="13" y="363">' +
-            '<value name="NUM">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">3.1</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="math_on_list" x="13" y="413"></block>' +
-          '<block type="math_modulo" x="13" y="463">' +
-            '<value name="DIVIDEND">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">64</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="DIVISOR">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">10</field>'+
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="math_constrain" x="13" y="512">' +
-            '<value name="VALUE">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">50</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="LOW">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">1</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="HIGH">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">100</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="math_random_int" x="13" y="562">' +
-            '<value name="FROM">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">1</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="TO">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">100</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="math_random_float" x="13" y="612"></block>' +
-          '</xml>'),
-      color: '#5C68A6',
-      custom: null
-    };
+FactoryController.prototype.standardCategories['math'] = new Category('Math');
+FactoryController.prototype.standardCategories['math'].xml =
+    Blockly.Xml.textToDom(
+    '<xml>' +
+    '<block type="math_number" x="13" y="13"></block>' +
+    '<block type="math_arithmetic" x="13" y="63">' +
+      '<value name="A">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="B">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="math_single" x="13" y="113">' +
+      '<value name="NUM">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">9</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="math_trig" x="13" y="163">' +
+      '<value name="NUM">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">45</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="math_constant" x="13" y="213"></block>' +
+    '<block type="math_number_property" x="13" y="263">' +
+      '<value name="NUMBER_TO_CHECK">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="math_change" x="13" y="313">' +
+      '<value name="DELTA">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="math_round" x="13" y="363">' +
+      '<value name="NUM">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">3.1</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="math_on_list" x="13" y="413"></block>' +
+    '<block type="math_modulo" x="13" y="463">' +
+      '<value name="DIVIDEND">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">64</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="DIVISOR">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">10</field>'+
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="math_constrain" x="13" y="512">' +
+      '<value name="VALUE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">50</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="LOW">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="HIGH">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">100</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="math_random_int" x="13" y="562">' +
+      '<value name="FROM">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">1</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="TO">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">100</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="math_random_float" x="13" y="612"></block>' +
+    '</xml>');
+FactoryController.prototype.standardCategories['math'].color = '#5C68A6';
 
-standardCategories['text'] = {
-      xml: Blockly.Xml.textToDom(
-          '<xml>' +
-          '<block type="text" x="13" y="13"></block>' +
-          '<block type="text_join" x="13" y="63"></block>' +
-          '<block type="text_append" x="13" y="138">' +
-            '<value name="TEXT">' +
-              '<shadow type="text"></shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="text_length" x="13" y="188">' +
-            '<value name="VALUE">' +
-              '<shadow type="text">' +
-                '<field name="TEXT">abc</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="text_isEmpty" x="13" y="238">' +
-            '<value name="VALUE">' +
-              '<shadow type="text">' +
-                '<field name="TEXT"></field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="text_indexOf" x="13" y="288">' +
-            '<value name="VALUE">' +
-              '<block type="variables_get">' +
-                '<field name="VAR">text</field>' +
-              '</block>' +
-            '</value>' +
-            '<value name="FIND">' +
-              '<shadow type="text">' +
-                '<field name="TEXT">abc</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="text_charAt" x="13" y="337">' +
-            '<value name="VALUE">' +
-              '<block type="variables_get">' +
-                '<field name="VAR">text</field>' +
-              '</block>' +
-            '</value>' +
-          '</block>' +
-          '<block type="text_getSubstring" x="13" y="387">' +
-            '<value name="STRING">' +
-              '<block type="variables_get">' +
-                '<field name="VAR">text</field>' +
-              '</block>' +
-            '</value>' +
-          '</block>' +
-          '<block type="text_changeCase" x="13" y="437">' +
-            '<value name="TEXT">' +
-              '<shadow type="text">' +
-                '<field name="TEXT">abc</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="text_trim" x="13" y="488">' +
-            '<value name="TEXT">' +
-              '<shadow type="text">' +
-                '<field name="TEXT">abc</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="text_print" x="13" y="538">' +
-            '<value name="TEXT">' +
-              '<shadow type="text">' +
-                '<field name="TEXT">abc</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="text_prompt_ext" x="13" y="588">' +
-            '<value name="TEXT">' +
-              '<shadow type="text">' +
-                '<field name="TEXT">abc</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '</xml>'),
-      color: '#5CA68D',
-      custom: null
-    };
+FactoryController.prototype.standardCategories['text'] = new Category('Text');
+FactoryController.prototype.standardCategories['text'].xml =
+    Blockly.Xml.textToDom(
+    '<xml>' +
+    '<block type="text" x="13" y="13"></block>' +
+    '<block type="text_join" x="13" y="63"></block>' +
+    '<block type="text_append" x="13" y="138">' +
+      '<value name="TEXT">' +
+        '<shadow type="text"></shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="text_length" x="13" y="188">' +
+      '<value name="VALUE">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">abc</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="text_isEmpty" x="13" y="238">' +
+      '<value name="VALUE">' +
+        '<shadow type="text">' +
+          '<field name="TEXT"></field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="text_indexOf" x="13" y="288">' +
+      '<value name="VALUE">' +
+        '<block type="variables_get">' +
+          '<field name="VAR">text</field>' +
+        '</block>' +
+      '</value>' +
+      '<value name="FIND">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">abc</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="text_charAt" x="13" y="337">' +
+      '<value name="VALUE">' +
+        '<block type="variables_get">' +
+          '<field name="VAR">text</field>' +
+        '</block>' +
+      '</value>' +
+    '</block>' +
+    '<block type="text_getSubstring" x="13" y="387">' +
+      '<value name="STRING">' +
+        '<block type="variables_get">' +
+          '<field name="VAR">text</field>' +
+        '</block>' +
+      '</value>' +
+    '</block>' +
+    '<block type="text_changeCase" x="13" y="437">' +
+      '<value name="TEXT">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">abc</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="text_trim" x="13" y="488">' +
+      '<value name="TEXT">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">abc</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="text_print" x="13" y="538">' +
+      '<value name="TEXT">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">abc</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="text_prompt_ext" x="13" y="588">' +
+      '<value name="TEXT">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">abc</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '</xml>');
+FactoryController.prototype.standardCategories['text'].color = '#5CA68D';
 
-standardCategories['lists'] = {
-      xml: Blockly.Xml.textToDom(
-          '<xml>' +
-          '<block type="lists_create_with" x="13" y="-187">' +
-            '<mutation items="0"></mutation>' +
-          '</block>' +
-          '<block type="lists_create_with"  x="13" y="-137"></block>' +
-          '<block type="lists_repeat" x="13" y="-37">' +
-            '<value name="NUM">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">5</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="lists_length" x="13" y="13" ></block>' +
-          '<block type="lists_isEmpty" x="13" y="63"></block>' +
-          '<block type="lists_indexOf" x="13" y="113">' +
-            '<value name="VALUE">' +
-              '<block type="variables_get">' +
-                '<field name="VAR">list</field>' +
-              '</block>' +
-            '</value>' +
-          '</block>' +
-          '<block type="lists_getIndex" x="13" y="162">' +
-            '<value name="VALUE">' +
-              '<block type="variables_get">' +
-                '<field name="VAR">list</field>' +
-              '</block>' +
-            '</value>' +
-          '</block>' +
-          '<block type="lists_setIndex" x="13" y="212">' +
-            '<value name="LIST">' +
-              '<block type="variables_get">' +
-                '<field name="VAR">list</field>' +
-              '</block>' +
-            '</value>' +
-          '</block>' +
-          '<block type="lists_getSublist" x="13" y="262">' +
-            '<value name="LIST">' +
-              '<block type="variables_get">' +
-                '<field name="VAR">list</field>' +
-              '</block>' +
-            '</value>' +
-          '</block>' +
-          '<block type="lists_split" x="13" y="312">' +
-            '<value name="DELIM">' +
-              '<shadow type="text">' +
-                '<field name="TEXT">,</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="lists_sort" x="13" y="362"></block>' +
-          '</xml>'),
-      color: '#745CA6',
-      custom: null
-    };
+FactoryController.prototype.standardCategories['lists'] = new Category('Lists');
+FactoryController.prototype.standardCategories['lists'].xml =
+    Blockly.Xml.textToDom(
+    '<xml>' +
+    '<block type="lists_create_with" x="13" y="-187">' +
+      '<mutation items="0"></mutation>' +
+    '</block>' +
+    '<block type="lists_create_with"  x="13" y="-137"></block>' +
+    '<block type="lists_repeat" x="13" y="-37">' +
+      '<value name="NUM">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">5</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="lists_length" x="13" y="13" ></block>' +
+    '<block type="lists_isEmpty" x="13" y="63"></block>' +
+    '<block type="lists_indexOf" x="13" y="113">' +
+      '<value name="VALUE">' +
+        '<block type="variables_get">' +
+          '<field name="VAR">list</field>' +
+        '</block>' +
+      '</value>' +
+    '</block>' +
+    '<block type="lists_getIndex" x="13" y="162">' +
+      '<value name="VALUE">' +
+        '<block type="variables_get">' +
+          '<field name="VAR">list</field>' +
+        '</block>' +
+      '</value>' +
+    '</block>' +
+    '<block type="lists_setIndex" x="13" y="212">' +
+      '<value name="LIST">' +
+        '<block type="variables_get">' +
+          '<field name="VAR">list</field>' +
+        '</block>' +
+      '</value>' +
+    '</block>' +
+    '<block type="lists_getSublist" x="13" y="262">' +
+      '<value name="LIST">' +
+        '<block type="variables_get">' +
+          '<field name="VAR">list</field>' +
+        '</block>' +
+      '</value>' +
+    '</block>' +
+    '<block type="lists_split" x="13" y="312">' +
+      '<value name="DELIM">' +
+        '<shadow type="text">' +
+          '<field name="TEXT">,</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="lists_sort" x="13" y="362"></block>' +
+    '</xml>');
+FactoryController.prototype.standardCategories['lists'].color = '#745CA6';
 
-standardCategories['colour'] = {
-      xml: Blockly.Xml.textToDom(
-          '<xml>' +
-          '<block type="colour_picker" x="13" y="13"></block>' +
-          '<block type="colour_random" x="13" y="63"></block>' +
-          '<block type="colour_rgb" x="13" y="113">' +
-            '<value name="RED">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">100</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="GREEN">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">50</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="BLUE">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">0</field>' +
-              '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '<block type="colour_blend" x="13" y="213">' +
-            '<value name="COLOUR1">' +
-              '<shadow type="colour_picker">' +
-                '<field name="COLOUR">#ff0000</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="COLOUR2">' +
-              '<shadow type="colour_picker">' +
-                '<field name="COLOUR">#3333ff</field>' +
-              '</shadow>' +
-            '</value>' +
-            '<value name="RATIO">' +
-              '<shadow type="math_number">' +
-                '<field name="NUM">0.5</field>' +
-             '</shadow>' +
-            '</value>' +
-          '</block>' +
-          '</xml>'),
-      color: '#A6745C',
-      custom: null
-    };
-standardCategories['variables'] = {
-      xml: Blockly.Xml.textToDom(
-          '<xml>' +
-          '</xml>'),
-      color: '#A65C81',
-      custom: 'VARIABLE'
-    };
+FactoryController.prototype.standardCategories['colour'] =
+    new Category('Colour');
+FactoryController.prototype.standardCategories['colour'].xml =
+    Blockly.Xml.textToDom(
+    '<xml>' +
+    '<block type="colour_picker" x="13" y="13"></block>' +
+    '<block type="colour_random" x="13" y="63"></block>' +
+    '<block type="colour_rgb" x="13" y="113">' +
+      '<value name="RED">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">100</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="GREEN">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">50</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="BLUE">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0</field>' +
+        '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '<block type="colour_blend" x="13" y="213">' +
+      '<value name="COLOUR1">' +
+        '<shadow type="colour_picker">' +
+          '<field name="COLOUR">#ff0000</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="COLOUR2">' +
+        '<shadow type="colour_picker">' +
+          '<field name="COLOUR">#3333ff</field>' +
+        '</shadow>' +
+      '</value>' +
+      '<value name="RATIO">' +
+        '<shadow type="math_number">' +
+          '<field name="NUM">0.5</field>' +
+       '</shadow>' +
+      '</value>' +
+    '</block>' +
+    '</xml>');
+FactoryController.prototype.standardCategories['colour'].color = '#A6745C';
 
-standardCategories['functions'] = {
-      xml: Blockly.Xml.textToDom(
-          '<xml>' +
-          '</xml>'),
-      color: '#9A5CA6',
-      custom: 'PROCEDURE'
-    };
+FactoryController.prototype.standardCategories['functions'] =
+    new Category('Functions');
+FactoryController.prototype.standardCategories['functions'].color = '#9A5CA6'
+FactoryController.prototype.standardCategories['functions'].custom =
+    'PROCEDURE';
+
+FactoryController.prototype.standardCategories['variables'] =
+    new Category('Variables');
+FactoryController.prototype.standardCategories['variables'].color = '#A65C81';
+FactoryController.prototype.standardCategories['variables'].custom = 'VARIABLE';

--- a/demos/workspacefactory/standard_categories.js
+++ b/demos/workspacefactory/standard_categories.js
@@ -7,11 +7,10 @@
  * @author Emma Dauterman (evd2014)
  */
 
-FactoryController.prototype.standardCategories = Object.create(null);
+FactoryController.standardCategories = Object.create(null);
 
-FactoryController.prototype.standardCategories['logic'] = new Category('Logic');
-FactoryController.prototype.standardCategories['logic'].xml =
-    Blockly.Xml.textToDom(
+FactoryController.standardCategories['logic'] = new Category('Logic');
+FactoryController.standardCategories['logic'].xml = Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="controls_if" x="13" y="13"></block>' +
     '<block type="logic_compare" x="13" y="88"></block>' +
@@ -21,11 +20,10 @@ FactoryController.prototype.standardCategories['logic'].xml =
     '<block type="logic_null" x="13" y="288"></block>' +
     '<block type="logic_ternary" x="13" y="338"></block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['logic'].color = '#5C81A6';
+FactoryController.standardCategories['logic'].color = '#5C81A6';
 
-FactoryController.prototype.standardCategories['loops'] = new Category('Loops');
-FactoryController.prototype.standardCategories['loops'].xml =
-    Blockly.Xml.textToDom(
+FactoryController.standardCategories['loops'] = new Category('Loops');
+FactoryController.standardCategories['loops'].xml = Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="controls_repeat_ext" x="13" y="13">' +
       '<value name="TIMES">' +
@@ -55,11 +53,10 @@ FactoryController.prototype.standardCategories['loops'].xml =
     '<block type="controls_forEach" x="12" y="313"></block>' +
     '<block type="controls_flow_statements" x="12" y="413"></block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['loops'].color = '#5CA65C';
+FactoryController.standardCategories['loops'].color = '#5CA65C';
 
-FactoryController.prototype.standardCategories['math'] = new Category('Math');
-FactoryController.prototype.standardCategories['math'].xml =
-    Blockly.Xml.textToDom(
+FactoryController.standardCategories['math'] = new Category('Math');
+FactoryController.standardCategories['math'].xml = Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="math_number" x="13" y="13"></block>' +
     '<block type="math_arithmetic" x="13" y="63">' +
@@ -154,11 +151,10 @@ FactoryController.prototype.standardCategories['math'].xml =
     '</block>' +
     '<block type="math_random_float" x="13" y="612"></block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['math'].color = '#5C68A6';
+FactoryController.standardCategories['math'].color = '#5C68A6';
 
-FactoryController.prototype.standardCategories['text'] = new Category('Text');
-FactoryController.prototype.standardCategories['text'].xml =
-    Blockly.Xml.textToDom(
+FactoryController.standardCategories['text'] = new Category('Text');
+FactoryController.standardCategories['text'].xml = Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="text" x="13" y="13"></block>' +
     '<block type="text_join" x="13" y="63"></block>' +
@@ -236,11 +232,10 @@ FactoryController.prototype.standardCategories['text'].xml =
       '</value>' +
     '</block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['text'].color = '#5CA68D';
+FactoryController.standardCategories['text'].color = '#5CA68D';
 
-FactoryController.prototype.standardCategories['lists'] = new Category('Lists');
-FactoryController.prototype.standardCategories['lists'].xml =
-    Blockly.Xml.textToDom(
+FactoryController.standardCategories['lists'] = new Category('Lists');
+FactoryController.standardCategories['lists'].xml = Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="lists_create_with" x="13" y="-187">' +
       '<mutation items="0"></mutation>' +
@@ -292,12 +287,11 @@ FactoryController.prototype.standardCategories['lists'].xml =
     '</block>' +
     '<block type="lists_sort" x="13" y="362"></block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['lists'].color = '#745CA6';
+FactoryController.standardCategories['lists'].color = '#745CA6';
 
-FactoryController.prototype.standardCategories['colour'] =
+FactoryController.standardCategories['colour'] =
     new Category('Colour');
-FactoryController.prototype.standardCategories['colour'].xml =
-    Blockly.Xml.textToDom(
+FactoryController.standardCategories['colour'].xml = Blockly.Xml.textToDom(
     '<xml>' +
     '<block type="colour_picker" x="13" y="13"></block>' +
     '<block type="colour_random" x="13" y="63"></block>' +
@@ -336,15 +330,15 @@ FactoryController.prototype.standardCategories['colour'].xml =
       '</value>' +
     '</block>' +
     '</xml>');
-FactoryController.prototype.standardCategories['colour'].color = '#A6745C';
+FactoryController.standardCategories['colour'].color = '#A6745C';
 
-FactoryController.prototype.standardCategories['functions'] =
+FactoryController.standardCategories['functions'] =
     new Category('Functions');
-FactoryController.prototype.standardCategories['functions'].color = '#9A5CA6'
-FactoryController.prototype.standardCategories['functions'].custom =
+FactoryController.standardCategories['functions'].color = '#9A5CA6'
+FactoryController.standardCategories['functions'].custom =
     'PROCEDURE';
 
-FactoryController.prototype.standardCategories['variables'] =
+FactoryController.standardCategories['variables'] =
     new Category('Variables');
-FactoryController.prototype.standardCategories['variables'].color = '#A65C81';
-FactoryController.prototype.standardCategories['variables'].custom = 'VARIABLE';
+FactoryController.standardCategories['variables'].color = '#A65C81';
+FactoryController.standardCategories['variables'].custom = 'VARIABLE';

--- a/demos/workspacefactory/style.css
+++ b/demos/workspacefactory/style.css
@@ -44,7 +44,6 @@ button {
   font-size: large;
   margin: 0 5px;
   padding: 10px;
-  z-index: -1;
 }
 
 button:hover:not(:disabled) {

--- a/demos/workspacefactory/style.css
+++ b/demos/workspacefactory/style.css
@@ -155,7 +155,7 @@ td {
     background-color: #f9f9f9;
     box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
     display: none;
-    min-width: 160px;
+    min-width: 170px;
     opacity: 1;
     position: absolute;
     z-index: 1;

--- a/demos/workspacefactory/style.css
+++ b/demos/workspacefactory/style.css
@@ -44,6 +44,7 @@ button {
   font-size: large;
   margin: 0 5px;
   padding: 10px;
+  z-index: -1;
 }
 
 button:hover:not(:disabled) {
@@ -141,4 +142,39 @@ td {
 
 .goog-popupcolorpicker {
   position: absolute;
+}
+
+/* The container <div> - needed to position the dropdown content */
+.dropdown {
+    position: relative;
+    display: inline-block;
+}
+
+/* Dropdown Content (Hidden by Default) */
+.dropdown-content {
+    background-color: #f9f9f9;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    display: none;
+    min-width: 160px;
+    opacity: 1;
+    position: absolute;
+    z-index: 1;
+}
+
+/* Links inside the dropdown */
+.dropdown-content a {
+    color: black;
+    display: block;
+    padding: 12px 16px;
+    text-decoration: none;
+}
+
+/* Change color of dropdown links on hover */
+.dropdown-content a:hover {
+  background-color: #f1f1f1
+}
+
+/* Show the dropdown menu */
+.show {
+  display: block;
 }

--- a/demos/workspacefactory/style.css
+++ b/demos/workspacefactory/style.css
@@ -153,7 +153,7 @@ td {
 /* Dropdown Content (Hidden by Default) */
 .dropdown-content {
     background-color: #f9f9f9;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,.2);
     display: none;
     min-width: 170px;
     opacity: 1;


### PR DESCRIPTION
Added feature to allow the user to load a standard Blockly category (logic, loops, math, etc.) by name as a new category. Also changed the add and edit buttons to be dropdowns to (for the add dropdown) add a new category or load a standard category, and (for the edit dropdown) edit the name or the color. Also moved calls to updatePreview to other functions (adding, deleting, editing) and listened for Blockly move and delete events to eliminate the need for the "Update Preview" button (removed button).
![standard category add dropdown](https://cloud.githubusercontent.com/assets/18580768/17159806/173269d0-5355-11e6-926a-a94eb00c2170.png)
![standard category with edit color dropdown](https://cloud.githubusercontent.com/assets/18580768/17159816/2e2bfe80-5355-11e6-8090-148721c924b6.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/25)

<!-- Reviewable:end -->
