### PR TITLE
Workspace Factory #6: Separators

### DIFF
--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -36,13 +36,12 @@ FactoryController = function(toolboxWorkspace, previewWorkspace) {
 };
 
 /**
- * Attached to "Add Category" button. Currently prompts the user for a name,
- * checking that it's valid (not used before), and then creates a tab and
- * switches to it.
+ * Currently prompts the user for a name, checking that it's valid (not used
+ * before), and then creates a tab and switches to it.
  */
 FactoryController.prototype.addCategory = function() {
   // Check if it's the first category added.
-  var firstCategory = !this.model.hasCategories();
+  var firstCategory = !this.model.hasToolbox();
   // Give the option to save blocks if their workspace is not empty and they
   // are creating their first category.
   if (firstCategory && this.toolboxWorkspace.getAllBlocks().length > 0) {
@@ -62,7 +61,7 @@ FactoryController.prototype.addCategory = function() {
     }
   }
   // After possibly creating a category, check again if it's the first category.
-  firstCategory = !this.model.hasCategories();
+  firstCategory = !this.model.hasToolbox();
   // Get name from user.
   name = this.promptForNewCategoryName('Enter the name of your new category: ');
   if (!name) {  //Exit if cancelled.
@@ -73,7 +72,7 @@ FactoryController.prototype.addCategory = function() {
   this.addCategoryToView(name, this.model.getCategoryIdByName(name),
       firstCategory);
   // Switch to category.
-  this.switchCategory(this.model.getCategoryIdByName(name));
+  this.switchElement(this.model.getCategoryIdByName(name));
   // Update preview.
   this.updatePreview();
 };
@@ -88,53 +87,68 @@ FactoryController.prototype.addCategory = function() {
  * @param {boolean} firstCategory True if it's the first category created,
  * false otherwise.
  */
+FactoryController.prototype.createCategory = function(name, firstCategory) {
+  // Create empty category
+  var category = new ListElement(ListElement.TYPE_CATEGORY, name);
+  this.model.addElementToList(category);
+  // Create new category.
+  var tab = this.view.addCategoryRow(name, category.id, firstCategory);
+  this.addClickToSwitch(tab, category.id);
 
-FactoryController.prototype.addCategoryToView = function(name, id,
-    firstCategory) {
-  var tab = this.view.addCategoryRow(name, id, firstCategory);
+};
+
+/**
+ * Given a tab and a ID to be associated to that tab, adds a listener to
+ * that tab so that when the user clicks on the tab, it switches to the
+ * element associated with that ID.
+ *
+ * @param {!Element} tab The DOM element to add the listener to.
+ * @param {!string} id The ID of the element to switch to when tab is clicked.
+ */
+FactoryController.prototype.addClickToSwitch = function(tab, id) {
   var self = this;
-  var clickFunction = function(id) {  // Keep this in scope for switchCategory
+  var clickFunction = function(id) {  // Keep this in scope for switchElement
     return function() {
-      self.switchCategory(id);
+      self.switchElement(id);
     };
   };
   this.view.bindClick(tab, clickFunction(id));
-}
+};
 
 /**
- * Attached to "Remove Category" button. Checks if the user wants to delete
- * the current category.  Removes the category and switches to another category.
- * When the last category is removed, it switches to a single flyout mode.
+ * Attached to "-" button. Checks if the user wants to delete
+ * the current element.  Removes the element and switches to another element.
+ * When the last element is removed, it switches to a single flyout mode.
  *
  */
-FactoryController.prototype.removeCategory = function() {
+FactoryController.prototype.removeElement = function() {
   // Check that there is a currently selected category to remove.
   if (!this.model.getSelected()) {
     return;
   }
   // Check if user wants to remove current category.
-  var check = confirm('Are you sure you want to delete the currently selected'
-        + ' category? ');
+  var check = confirm('Are you sure you want to delete the currently selected '
+        + this.model.getSelected().type + '?');
   if (!check) { // If cancelled, exit.
     return;
   }
   var selectedId = this.model.getSelectedId();
-  var selectedIndex = this.model.getIndexByCategoryId(selectedId);
-  // Delete category visually.
-  this.view.deleteCategoryRow(selectedId, selectedIndex);
-  // Delete category in model.
-  this.model.deleteCategoryEntry(selectedIndex);
-  // Find next logical category to switch to.
-  var next = this.model.getCategoryByIndex(selectedIndex);
-  if (!next && this.model.hasCategories()) {
-    next = this.model.getCategoryByIndex(selectedIndex - 1);
+  var selectedIndex = this.model.getIndexByElementId(selectedId);
+  // Delete element visually.
+  this.view.deleteElementRow(selectedId, selectedIndex);
+  // Delete element in model.
+  this.model.deleteElementFromList(selectedIndex);
+  // Find next logical element to switch to.
+  var next = this.model.getElementByIndex(selectedIndex);
+  if (!next && this.model.hasToolbox()) {
+    next = this.model.getElementByIndex(selectedIndex - 1);
   }
   var nextId = next ? next.id : null;
-  // Open next category.
-  this.clearAndLoadCategory(nextId);
+  // Open next element.
+  this.clearAndLoadElement(nextId);
   if (!nextId) {
-    alert('You currently have no categories. All your blocks will be ' +
-        'displayed in a single flyout.');
+    alert('You currently have no categories or separators. All your blocks' +
+        ' will be displayed in a single flyout.');
   }
   // Update preview.
   this.updatePreview();
@@ -157,47 +171,56 @@ FactoryController.prototype.promptForNewCategoryName = function(promptString) {
 }
 
 /**
- * Switches to a new tab for the category given by name. Stores XML and blocks
+ * Switches to a new tab for the element given by ID. Stores XML and blocks
  * to reload later, updates selected accordingly, and clears the workspace
- * and clears undo, then loads the new category.
+ * and clears undo, then loads the new element.
  *
- * @param {!string} id ID of tab to be opened, must be valid category ID.
+ * @param {!string} id ID of tab to be opened, must be valid element ID.
  */
-FactoryController.prototype.switchCategory = function(id) {
-  // Caches information to reload or generate xml if switching to/from category.
+FactoryController.prototype.switchElement = function(id) {
+  // Caches information to reload or generate xml if switching to/from element.
+  // Only saves if a category is selected.
   if (this.model.getSelectedId() != null && id != null) {
-    this.model.saveCategoryEntry(this.model.getSelected(),
-        this.toolboxWorkspace);
+    this.model.getSelected().saveFromWorkspace(this.toolboxWorkspace);
   }
-  // Load category.
-  this.clearAndLoadCategory(id);
+  // Load element.
+  this.clearAndLoadElement(id);
 };
 
 /**
- * Switches to a new tab for the category by name. Helper for switchCategory.
- * Updates selected, clears the workspace and clears undo, loads a new category.
+ * Switches to a new tab for the element by ID. Helper for switchElement.
+ * Updates selected, clears the workspace and clears undo, loads a new element.
  *
  * @param {!string} id ID of category to load
  */
-FactoryController.prototype.clearAndLoadCategory = function(id) {
-  // Unselect current tab if switching to/from a category.
+FactoryController.prototype.clearAndLoadElement = function(id) {
+  // Unselect current tab if switching to and from an element.
   if (this.model.getSelectedId() != null && id != null) {
     this.view.setCategoryTabSelection(this.model.getSelectedId(), false);
+  }
+  // If switching from a separator, enable workspace in view.
+  if (this.model.getSelectedId() != null && this.model.getSelected().type ==
+      ListElement.TYPE_SEPARATOR) {
+    this.view.disableWorkspace(false);
   }
   // Set next category.
   this.model.setSelectedById(id);
   // Clear workspace.
   this.toolboxWorkspace.clear();
   this.toolboxWorkspace.clearUndo();
-  // Loads next category if switching to a category.
+  // Loads next category if switching to an element.
   if (id != null) {
     this.view.setCategoryTabSelection(id, true);
     Blockly.Xml.domToWorkspace(this.model.getSelectedXml(),
         this.toolboxWorkspace);
+    // Disable workspace if switching to a separator.
+    if (this.model.getSelected().type == ListElement.TYPE_SEPARATOR) {
+      this.view.disableWorkspace(true);
+    }
   }
   // Update category editing buttons.
-  this.view.updateState(this.model.getIndexByCategoryId
-      (this.model.getSelectedId()));
+  this.view.updateState(this.model.getIndexByElementId
+      (this.model.getSelectedId()), this.model.getSelected().type);
 };
 
 /**
@@ -231,7 +254,7 @@ FactoryController.prototype.printConfig = function() {
  * Updates the preview workspace based on the toolbox workspace. If switching
  * from no categories to categories or categories to no categories, reinjects
  * Blockly with reinjectPreview, otherwise just updates without reinjecting.
- * Called whenever a category is created, removed, or modified and when
+ * Called whenever a list element is created, removed, or modified and when
  * Blockly move and delete events are fired. Do not call on create events
  * or disabling will cause the user to "drop" their current blocks.
  */
@@ -290,9 +313,10 @@ FactoryController.prototype.reinjectPreview = function(tree) {
  * Continues prompting the user until they input a category name that is not
  * currently in use, exits if user presses cancel.
  */
-FactoryController.prototype.changeName = function() {
-  // Return if no category selected.
-  if (!this.model.getSelected()) {
+FactoryController.prototype.changeCategoryName = function() {
+  // Return if no category selected or element a separator.
+  if (!this.model.getSelected() ||
+      this.model.getSelected().type == ListElement.TYPE_SEPARATOR) {
     return;
   }
   // Get new name from user.
@@ -302,71 +326,77 @@ FactoryController.prototype.changeName = function() {
     return;
   }
   // Change category name.
-  this.model.changeCategoryName(newName, this.model.getSelected());
+  this.model.getSelected().changeName(newName);
   this.view.updateCategoryName(newName, this.model.getSelectedId());
   // Update preview.
   this.updatePreview();
 };
 
 /**
- * Tied to arrow up and arrow down buttons. Swaps with the category above or
- * below the currently selected category (offset categories away from the
- * current category). Updates state to enable the correct category editing
+ * Tied to arrow up and arrow down buttons. Swaps with the element above or
+ * below the currently selected element (offset categories away from the
+ * current element). Updates state to enable the correct element editing
  * buttons.
  *
- * @param {int} offset The index offset from the currently selected category
- * to swap with. Positive if the category to be swapped with is below, negative
- * if the category to be swapped with is above.
+ * @param {int} offset The index offset from the currently selected element
+ * to swap with. Positive if the element to be swapped with is below, negative
+ * if the element to be swapped with is above.
  */
-FactoryController.prototype.moveCategory = function(offset) {
+FactoryController.prototype.moveElement = function(offset) {
   var curr = this.model.getSelected();
-  if (!curr) {  // Return if no selected category.
+  if (!curr) {  // Return if no selected element.
     return;
   }
-  var currIndex = this.model.getIndexByCategoryId(curr.id);
-  var swapIndex = this.model.getIndexByCategoryId(curr.id) + offset;
-  var swap = this.model.getCategoryByIndex(swapIndex);
+  var currIndex = this.model.getIndexByElementId(curr.id);
+  var swapIndex = this.model.getIndexByElementId(curr.id) + offset;
+  var swap = this.model.getElementByIndex(swapIndex);
   if (!swap) {  // Return if cannot swap in that direction.
     return;
   }
-  // Move currently selected category to index of other category.
+  // Move currently selected element to index of other element.
   // Indexes must be valid because confirmed that curr and swap exist.
-  this.moveCategoryToIndex(curr, swapIndex, currIndex);
-  // Update category editing buttons.
-  this.view.updateState(swapIndex);
+  this.moveElementToIndex(curr, swapIndex, currIndex);
+  // Update element editing buttons.
+  this.view.updateState(swapIndex, this.model.getSelected().type);
   // Update preview.
   this.updatePreview();
 };
 
 /**
- * Moves a category to a specified index and updates the model and view
+ * Moves a element to a specified index and updates the model and view
  * accordingly. Helper functions throw an error if indexes are out of bounds.
  *
- * @param {!Category} category The category to move.
- * @param {int} newIndex The index to insert the category at.
- * @param {int} oldIndex The index the category is currently at.
+ * @param {!Element} element The element to move.
+ * @param {int} newIndex The index to insert the element at.
+ * @param {int} oldIndex The index the element is currently at.
  */
-FactoryController.prototype.moveCategoryToIndex = function(category, newIndex,
+FactoryController.prototype.moveElementToIndex = function(element, newIndex,
     oldIndex) {
-  this.model.moveCategoryToIndex(category, newIndex, oldIndex);
-  this.view.moveTabToIndex(category.id, newIndex, oldIndex);
+  this.model.moveElementToIndex(element, newIndex, oldIndex);
+  this.view.moveTabToIndex(element.id, newIndex, oldIndex);
 };
 
 /**
- * Changes the color of the selected category.
+ * Changes the color of the selected category. Return if selected element is
+ * a separator.
  *
  * @param {!string} color The color to change the selected category. Must be
  * a valid CSS string.
  */
 FactoryController.prototype.changeSelectedCategoryColor = function(color) {
-  var selectedId = this.model.getSelectedId();
-  this.model.setCategoryColorById(selectedId, color);
-  this.view.setBorderColor(selectedId, color);
+  // Return if no category selected or element a separator.
+  if (!this.model.getSelected() ||
+      this.model.getSelected().type == ListElement.TYPE_SEPARATOR) {
+    return;
+  }
+  // Change color of selected category.
+  this.model.getSelected().changeColor(color);
+  this.view.setBorderColor(this.model.getSelectedId(), color);
   this.updatePreview();
 };
 
 /**
- * Tied to the "Pre-existing Category" dropdown option, this function prompts
+ * Tied to the "Standard Category" dropdown option, this function prompts
  * the user for a name of a standard Blockly category (case insensitive) and
  * loads it as a new category and switches to it. Leverages standardCategories
  * map in standard_categories.js.
@@ -383,15 +413,17 @@ FactoryController.prototype.loadCategory = function() {
 
   // Copy the standard category in the model.
   var standardCategory = this.standardCategories[name.toLowerCase()];
-  var copy = this.model.copyCategory(standardCategory);
+  var copy = standardCategory.copy();
+  this.model.addElementToList(copy);
   // Update the copy in the view.
-  this.addCategoryToView(copy.name, copy.id, this.model.getSelected() == null);
+  var tab = this.view.addCategoryRow(copy.name, copy.id, this.model.getSelected() == null);
+  this.addClickToSwitch(tab, copy.id);
   // Color the category tab in the view.
   if (copy.color) {
     this.view.setBorderColor(copy.id, copy.color);
   }
   // Switch to loaded category.
-  this.switchCategory(copy.id);
+  this.switchElement(copy.id);
   // Update preview.
   this.updatePreview();
 };
@@ -411,4 +443,26 @@ FactoryController.prototype.isStandardCategoryName = function(name) {
     }
   }
   return false;
+};
+
+/**
+ * Connected to the "add separator" dropdown option. If categories already
+ * exist, adds a separator to the model and view. Does not switch to select
+ * the separator, and updates the preview.
+ */
+FactoryController.prototype.addSeparator = function() {
+  // Don't allow the user to add a separator if a category has not been created.
+  if (!this.model.hasToolbox()) {
+    alert('Add a category before adding a separator.');
+    return;
+  }
+  // Create the separator in the model.
+  var separator = new ListElement(ListElement.TYPE_SEPARATOR);
+  this.model.addElementToList(separator);
+  // Create the separator in the view.
+  var tab = this.view.addSeparatorTab(separator.id);
+  this.addClickToSwitch(tab, separator.id);
+  // Switch to the separator and update the preview.
+  this.switchElement(separator.id);
+  this.updatePreview();
 };

--- a/demos/workspacefactory/factory_model.js
+++ b/demos/workspacefactory/factory_model.js
@@ -235,7 +235,7 @@ FactoryModel.prototype.copyElement = function(original) {
 
 
 /**
- * Class for a ListElement
+ * Class for a ListElement.
  * @constructor
  */
 ListElement = function(type, opt_name) {

--- a/demos/workspacefactory/factory_view.js
+++ b/demos/workspacefactory/factory_view.js
@@ -1,6 +1,6 @@
 /**
  * Controls the UI elements for workspace factory, mainly the category tabs.
- * Also includes downlaoding files because that interacts directly with the DOM.
+ * Also includes downloading files because that interacts directly with the DOM.
  * Depends on FactoryController (for adding mouse listeners). Tabs for each
  * category are stored in tab map, which associates a unique ID for a
  * category with a particular tab.
@@ -13,7 +13,8 @@
   * @constructor
   */
 
-FactoryView = function(){
+FactoryView = function() {
+  // For each tab, maps ID of a ListElement to the td DOM element.
   this.tabMap = Object.create(null);
 };
 
@@ -51,7 +52,7 @@ FactoryView.prototype.addCategoryRow = function(name, id, firstCategory) {
  * @param {!string} id ID of category to be deleted.
  * @param {!string} name The name of the category to be deleted.
  */
-FactoryView.prototype.deleteCategoryRow = function(id, index) {
+FactoryView.prototype.deleteElementRow = function(id, index) {
   // Delete tab entry.
   delete this.tabMap[id];
   // Delete tab row.
@@ -74,10 +75,14 @@ FactoryView.prototype.deleteCategoryRow = function(id, index) {
  *
  * TODO(evd2014): Switch to using CSS to add/remove styles.
  *
- * @param {int} selectedIndex The index of the currently selected category.
+ * @param {int} selectedIndex The index of the currently selected category,
+ * -1 if no categories created.
+ * @param {!string} selectedType The type of the selected ListElement.
+ * ListElement.TYPE_CATEGORY or ListElement.TYPE_SEPARATOR.
  */
-FactoryView.prototype.updateState = function(selectedIndex) {
-  document.getElementById('button_edit').disabled = selectedIndex < 0;
+FactoryView.prototype.updateState = function(selectedIndex, selectedType) {
+  document.getElementById('button_edit').disabled = selectedIndex < 0 ||
+      selectedType != ListElement.TYPE_CATEGORY;
   document.getElementById('button_remove').disabled = selectedIndex < 0;
   document.getElementById('button_up').disabled =
       selectedIndex <= 0 ? true : false;
@@ -198,4 +203,37 @@ FactoryView.prototype.setBorderColor = function(id, color) {
   tab.style.borderLeftWidth = "8px";
   tab.style.borderLeftStyle = "solid";
   tab.style.borderColor = color;
-}
+};
+
+/**
+ * Given a separator ID, creates a corresponding tab in the view, updates
+ * tab map, and returns the tab.
+ *
+ * @param {!string} id The ID of the separator.
+ * @param {!Element} The td DOM element representing the separator.
+ */
+FactoryView.prototype.addSeparatorTab = function(id) {
+  // Create separator.
+  var table = document.getElementById('categoryTable');
+  var count = table.rows.length;
+  var row = table.insertRow(count);
+  var nextEntry = row.insertCell(0);
+  // Configure separator.
+  nextEntry.style.height = '10px';
+  // Store and return separator.
+  this.tabMap[id] = table.rows[count].cells[0];
+  return nextEntry;
+};
+
+/**
+ * Disables or enables the workspace by putting a div over or under the
+ * toolbox workspace, depending on the value of disable. Used when switching
+ * to/from separators where the user shouldn't be able to drag blocks into
+ * the workspace.
+ *
+ * @param {boolean} disable True if the workspace should be disabled, false
+ * if it should be enabled.
+ */
+FactoryView.prototype.disableWorkspace = function(disable) {
+  document.getElementById('disable_div').style.zIndex = disable ? 1 : -1;
+};

--- a/demos/workspacefactory/index.html
+++ b/demos/workspacefactory/index.html
@@ -41,6 +41,7 @@ goog.require('goog.ui.ColorPicker');
   <p>Drag blocks into your toolbox</p>
   <section id="toolbox_section">
     <div id="toolbox_blocks" class="content"></div>
+    <div id='disable_div'></div>
   </section>
   <aside id="category_section">
     <table id="categoryTable">
@@ -52,6 +53,7 @@ goog.require('goog.ui.ColorPicker');
     <div id="dropdown_add" class="dropdown-content">
       <a id='dropdown_newCategory'>New Category</a>
       <a id='dropdown_loadCategory'>Standard Category</a>
+      <a id='dropdown_separator'>Separator</a>
     </div>
     </div>
     <button id="button_remove">-</button>
@@ -479,8 +481,12 @@ goog.require('goog.ui.ColorPicker');
     controller.loadCategory();
     document.getElementById('dropdown_add').classList.remove("show");
   };
+  var separatorWrapper = function() {
+    controller.addSeparator();
+    document.getElementById('dropdown_add').classList.remove("show");
+  };
   var removeWrapper = function() {
-    controller.removeCategory();
+    controller.removeElement();
   };
   var exportWrapper = function() {
     controller.exportConfig();
@@ -489,16 +495,16 @@ goog.require('goog.ui.ColorPicker');
     controller.printConfig();
   };
   var upWrapper = function() {
-    controller.moveCategory(-1);
+    controller.moveElement(-1);
   };
   var downWrapper = function() {
-    controller.moveCategory(1);
+    controller.moveElement(1);
   };
   var editWrapper = function() {
     document.getElementById('dropdown_edit').classList.toggle("show");
   };
   var nameWrapper = function() {
-    controller.changeName();
+    controller.changeCategoryName();
     document.getElementById('dropdown_edit').classList.remove("show");
   };
 
@@ -508,6 +514,8 @@ goog.require('goog.ui.ColorPicker');
       ('click', newCategoryWrapper);
   document.getElementById('dropdown_loadCategory').addEventListener
       ('click', loadCategoryWrapper);
+  document.getElementById('dropdown_separator').addEventListener
+      ('click', separatorWrapper);
   document.getElementById('button_remove').addEventListener
       ('click', removeWrapper);
   document.getElementById('button_export').addEventListener
@@ -535,15 +543,17 @@ goog.require('goog.ui.ColorPicker');
         controller.changeSelectedCategoryColor(popupPicker.getSelectedColor());
         document.getElementById('dropdown_edit').classList.remove("show");
       });
+
   // Disable category editing buttons until categories are created.
   document.getElementById('button_remove').disabled = true;
   document.getElementById('button_edit').disabled = true;
   document.getElementById('button_up').disabled = true;
   document.getElementById('button_down').disabled = true;
+
   // Listen for Blockly move and delete events to update preview.
   // Not listening for Blockly create events because causes the user to drop
-  // blocks when dragging them into workspace. Could cause problems if ever load
-  // blocks into workspace directly without calling updatePreview.
+  // blocks when dragging them into workspace. Could cause problems if
+  // blocks loaded into workspace directly without calling updatePreview.
   toolboxWorkspace.addChangeListener(function(e) {
     if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
       controller.updatePreview();

--- a/demos/workspacefactory/standard_categories.js
+++ b/demos/workspacefactory/standard_categories.js
@@ -9,7 +9,8 @@
 
 FactoryController.prototype.standardCategories = Object.create(null);
 
-FactoryController.prototype.standardCategories['logic'] = new Category('Logic');
+FactoryController.prototype.standardCategories['logic'] =
+    new ListElement(ListElement.TYPE_CATEGORY, 'Logic');
 FactoryController.prototype.standardCategories['logic'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
@@ -23,7 +24,8 @@ FactoryController.prototype.standardCategories['logic'].xml =
     '</xml>');
 FactoryController.prototype.standardCategories['logic'].color = '#5C81A6';
 
-FactoryController.prototype.standardCategories['loops'] = new Category('Loops');
+FactoryController.prototype.standardCategories['loops'] =
+    new ListElement(ListElement.TYPE_CATEGORY, 'Loops');
 FactoryController.prototype.standardCategories['loops'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
@@ -57,7 +59,8 @@ FactoryController.prototype.standardCategories['loops'].xml =
     '</xml>');
 FactoryController.prototype.standardCategories['loops'].color = '#5CA65C';
 
-FactoryController.prototype.standardCategories['math'] = new Category('Math');
+FactoryController.prototype.standardCategories['math'] =
+    new ListElement(ListElement.TYPE_CATEGORY, 'Math');
 FactoryController.prototype.standardCategories['math'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
@@ -156,7 +159,8 @@ FactoryController.prototype.standardCategories['math'].xml =
     '</xml>');
 FactoryController.prototype.standardCategories['math'].color = '#5C68A6';
 
-FactoryController.prototype.standardCategories['text'] = new Category('Text');
+FactoryController.prototype.standardCategories['text'] =
+    new ListElement(ListElement.TYPE_CATEGORY, 'Text');
 FactoryController.prototype.standardCategories['text'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
@@ -238,7 +242,8 @@ FactoryController.prototype.standardCategories['text'].xml =
     '</xml>');
 FactoryController.prototype.standardCategories['text'].color = '#5CA68D';
 
-FactoryController.prototype.standardCategories['lists'] = new Category('Lists');
+FactoryController.prototype.standardCategories['lists'] =
+    new ListElement(ListElement.TYPE_CATEGORY, 'Lists');
 FactoryController.prototype.standardCategories['lists'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
@@ -295,7 +300,7 @@ FactoryController.prototype.standardCategories['lists'].xml =
 FactoryController.prototype.standardCategories['lists'].color = '#745CA6';
 
 FactoryController.prototype.standardCategories['colour'] =
-    new Category('Colour');
+    new ListElement(ListElement.TYPE_CATEGORY, 'Colour');
 FactoryController.prototype.standardCategories['colour'].xml =
     Blockly.Xml.textToDom(
     '<xml>' +
@@ -339,12 +344,12 @@ FactoryController.prototype.standardCategories['colour'].xml =
 FactoryController.prototype.standardCategories['colour'].color = '#A6745C';
 
 FactoryController.prototype.standardCategories['functions'] =
-    new Category('Functions');
+    new ListElement(ListElement.TYPE_CATEGORY, 'Functions');
 FactoryController.prototype.standardCategories['functions'].color = '#9A5CA6'
 FactoryController.prototype.standardCategories['functions'].custom =
     'PROCEDURE';
 
 FactoryController.prototype.standardCategories['variables'] =
-    new Category('Variables');
+    new ListElement(ListElement.TYPE_CATEGORY, 'Variables');
 FactoryController.prototype.standardCategories['variables'].color = '#A65C81';
 FactoryController.prototype.standardCategories['variables'].custom = 'VARIABLE';

--- a/demos/workspacefactory/style.css
+++ b/demos/workspacefactory/style.css
@@ -76,11 +76,13 @@ td {
 }
 
 #toolbox_section {
+  height: 480px;
   width: 80%;
+  position: relative;
 }
 
 #toolbox_blocks {
-  height: 480px;
+  height: 100%;
   width: 100%;
 }
 
@@ -101,6 +103,17 @@ td {
   width: 20%;
 }
 
+#disable_div {
+  background-color: white;
+  height: 100%;
+  left: 0;
+  opacity: .5;
+  position: absolute;
+  top: 0;
+  width: 100%;
+  z-index: -1;  /* Start behind workspace */
+}
+
 /* Rules for Closure popup color picker */
 .goog-palette {
   outline: none;
@@ -119,10 +132,10 @@ td {
 }
 
 .goog-palette-colorswatch {
-  position: relative;
-  height: 13px;
-  width: 15px;
   border: 1px solid #000000;
+  height: 13px;
+  position: relative;
+  width: 15px;
 }
 
 .goog-palette-cell-hover .goog-palette-colorswatch {
@@ -135,7 +148,7 @@ td {
 }
 
 .goog-palette-table {
-  border: 1px solid #000000;
+  border: 1px solid #000;
   border-collapse: collapse;
 }
 


### PR DESCRIPTION
Gives the user the option to create separators in their toolbox. The user can select a separator, but has none of the category-specific editing option (can only remove and move the separator), and the workspace is disabled when a separator is selected. This required refactoring the model to be a toolboxList of ListElements, each of which has a type to tell which are categories and which are separators. Also required refactoring many method names. 
![separators](https://cloud.githubusercontent.com/assets/18580768/17227657/356dcc9e-54c4-11e6-925f-358b33b7dc4f.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/26)

<!-- Reviewable:end -->
