### PR TITLE
Workspace Factory #7: Variable/Function Category Validation and View

### DIFF
--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -94,7 +94,6 @@ FactoryController.prototype.createCategory = function(name, firstCategory) {
   // Create new category.
   var tab = this.view.addCategoryRow(name, category.id, firstCategory);
   this.addClickToSwitch(tab, category.id);
-
 };
 
 /**
@@ -220,7 +219,7 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
   }
   // Update category editing buttons.
   this.view.updateState(this.model.getIndexByElementId
-      (this.model.getSelectedId()), this.model.getSelected().type);
+      (this.model.getSelectedId()), this.model.getSelected());
 };
 
 /**
@@ -357,7 +356,7 @@ FactoryController.prototype.moveElement = function(offset) {
   // Indexes must be valid because confirmed that curr and swap exist.
   this.moveElementToIndex(curr, swapIndex, currIndex);
   // Update element editing buttons.
-  this.view.updateState(swapIndex, this.model.getSelected().type);
+  this.view.updateState(swapIndex, this.model.getSelected());
   // Update preview.
   this.updatePreview();
 };
@@ -411,10 +410,28 @@ FactoryController.prototype.loadCategory = function() {
     }
   } while (!this.isStandardCategoryName(name));
 
+  // Check if the user can create that standard category.
+  if (this.model.hasVariables() && name.toLowerCase() == 'variables') {
+    alert('A Variables category already exists. You cannot create multiple' +
+        ' variables categories.');
+    return;
+  }
+  if (this.model.hasProcedures() && name.toLowerCase() == 'functions') {
+    alert('A Functions category already exists. You cannot create multiple' +
+        ' functions categories.');
+    return;
+  }
+  // Check if the user can create a category with that name.
+  var standardCategory = this.standardCategories[name.toLowerCase()]
+  if (this.model.hasCategoryByName(standardCategory.name)) {
+    alert('You already have a category with the name ' + standardCategory.name
+        + '. Rename your category and try again.');
+    return;
+  }
   // Copy the standard category in the model.
-  var standardCategory = this.standardCategories[name.toLowerCase()];
   var copy = standardCategory.copy();
   this.model.addElementToList(copy);
+
   // Update the copy in the view.
   var tab = this.view.addCategoryRow(copy.name, copy.id, this.model.getSelected() == null);
   this.addClickToSwitch(tab, copy.id);

--- a/demos/workspacefactory/factory_model.js
+++ b/demos/workspacefactory/factory_model.js
@@ -16,6 +16,12 @@
 FactoryModel = function() {
   // Ordered list of ListElement objects.
   this.toolboxList = [];
+  // String name of current selected list element, null if no list elements.
+  this.selected = null;
+  // Boolean for if a Variable category has been added.
+  this.hasVariableCategory = false;
+  // Boolean for if a Procedure category has been added.
+  this.hasProcedureCategory = false;
 };
 
 // String name of current selected list element, null if no list elements.
@@ -39,6 +45,26 @@ FactoryModel.prototype.hasCategoryByName = function(name) {
 };
 
 /**
+ * Determines if a category with the 'VARIABLE' tag exists.
+ *
+ * @return {boolean} True if there exists a category with the Variables tag,
+ * false otherwise.
+ */
+FactoryModel.prototype.hasVariables = function() {
+  return this.hasVariableCategory;
+};
+
+/**
+ * Determines if a category with the 'PROCEDURE' tag exists.
+ *
+ * @return {boolean} True if there exists a category with the Procedures tag,
+ * false otherwise.
+ */
+FactoryModel.prototype.hasProcedures = function() {
+  return this.hasFunctionCategory;
+};
+
+/**
  * Determines if the user has any elements in the toolbox. Uses the length of
  * toolboxList.
  *
@@ -54,6 +80,10 @@ FactoryModel.prototype.hasToolbox = function() {
  * @param {!ListElement} element The element to be added to the list.
  */
 FactoryModel.prototype.addElementToList = function(element) {
+  this.hasVariableCategory = element.custom == 'VARIABLE' ? true :
+      this.hasVariableCategory;
+  this.hasProcedureCategory = element.custom == 'PROCEDURE' ? true :
+      this.hasProcedureCategory;
   this.toolboxList.push(element);
 };
 
@@ -63,9 +93,16 @@ FactoryModel.prototype.addElementToList = function(element) {
  * @param {int} index The index of the list element to delete.
  */
 FactoryModel.prototype.deleteElementFromList = function(index) {
+  // Check if index is out of bounds.
   if (index < 0 || index >= this.toolboxList.length) {
     return; // No entry to delete.
   }
+  // Check if need to update flags.
+  this.hasVariableCategory = this.toolboxList[index].custom == 'VARIABLE' ?
+      false : this.hasVariableCategory;
+  this.hasProcedureCategory = this.toolboxList[index].custom == 'PROCEDURE' ?
+      false : this.hasProcedureCategory;
+  // Remove element.
   this.toolboxList.splice(index, 1);
 };
 
@@ -211,31 +248,7 @@ FactoryModel.prototype.getCategoryIdByName = function(name) {
 };
 
 /**
- * Makes a copy of the original element, adds it to the toolboxList, and
- * returns it. Everything about the copy is identical except for its ID. Throws
- * an error if the original element is null.
- *
- * @param {!ListElement} original The category that should be copied.
- * @return {!ListElement} The copy of original.
- */
-FactoryModel.prototype.copyElement = function(original) {
-  if (!original) {
-    throw new Error('Trying to copy null category.');
-  }
-  copy = new ListElement(ListElement.TYPE_CATEGORY, original.name);
-  // Copy all attributes except ID.
-  copy.type = original.type;
-  copy.xml = original.xml;
-  copy.color = original.color;
-  copy.custom = original.custom;
-  // Add copy to the category list and return it.
-  this.toolboxList.push(copy);
-  return copy;
-};
-
-
-/**
- * Class for a ListElement.
+ * Class for a ListElement
  * @constructor
  */
 ListElement = function(type, opt_name) {

--- a/demos/workspacefactory/factory_view.js
+++ b/demos/workspacefactory/factory_view.js
@@ -68,27 +68,29 @@ FactoryView.prototype.deleteElementRow = function(id, index) {
 };
 
 /**
- * Given the index of the currently selected category, updates the state of
- * the buttons that allow the user to edit the categories. Updates the edit
- * name and arrow buttons. Should be called when adding or removing categories
- * or when changing to a new category or when swapping to a different category.
+ * Given the index of the currently selected element, updates the state of
+ * the buttons that allow the user to edit the list elements. Updates the edit
+ * and arrow buttons. Should be called when adding or removing elements
+ * or when changing to a new element or when swapping to a different element.
  *
  * TODO(evd2014): Switch to using CSS to add/remove styles.
  *
  * @param {int} selectedIndex The index of the currently selected category,
  * -1 if no categories created.
- * @param {!string} selectedType The type of the selected ListElement.
- * ListElement.TYPE_CATEGORY or ListElement.TYPE_SEPARATOR.
+ * @param {ListElement} selected The selected ListElement.
  */
-FactoryView.prototype.updateState = function(selectedIndex, selectedType) {
+FactoryView.prototype.updateState = function(selectedIndex, selected) {
+  // Disable/enable editing buttons as necessary.
   document.getElementById('button_edit').disabled = selectedIndex < 0 ||
-      selectedType != ListElement.TYPE_CATEGORY;
+      selected.type != ListElement.TYPE_CATEGORY;
   document.getElementById('button_remove').disabled = selectedIndex < 0;
   document.getElementById('button_up').disabled =
       selectedIndex <= 0 ? true : false;
   var table = document.getElementById('categoryTable');
   document.getElementById('button_down').disabled = selectedIndex >=
       table.rows.length - 1 || selectedIndex < 0 ? true : false;
+  // Disable/enable the workspace as necessary.
+  this.disableWorkspace(this.shouldDisableWorkspace(selected));
 };
 
 /**
@@ -236,4 +238,15 @@ FactoryView.prototype.addSeparatorTab = function(id) {
  */
 FactoryView.prototype.disableWorkspace = function(disable) {
   document.getElementById('disable_div').style.zIndex = disable ? 1 : -1;
+};
+
+/**
+ * Determines if the workspace should be disabled. The workspace should be
+ * disabled if category is a separator or has VARIABLE or PROCEDURE tags.
+ *
+ * @return {boolean} True if the workspace should be disabled, false otherwise.
+ */
+FactoryView.prototype.shouldDisableWorkspace = function(category) {
+  return category != null && (category.type == ListElement.SEPARATOR ||
+      category.custom == 'VARIABLE' || category.custom == 'PROCEDURE');
 };


### PR DESCRIPTION
Ensures that user can never have more than 1 function or more than 1 variable category. Because blocks cannot be added to these categories, disables the workspace when these categories are selected. Also fixes small bug by making sure that the user cannot add multiple categories of the same name by importing the same standard category twice. 

![variables](https://cloud.githubusercontent.com/assets/18580768/17228810/939518f4-54c9-11e6-9ecc-1c4a2be30e34.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/27)

<!-- Reviewable:end -->
