### PR TITLE
Workspace Factory #8: User-generated Shadow Blocks

### DIFF
--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -32,7 +32,7 @@ FactoryController = function(toolboxWorkspace, previewWorkspace) {
   // Updates the category tabs.
   this.view = new FactoryView();
   // Generates XML for categories.
-  this.generator = new FactoryGenerator(this.model, this.toolboxWorkspace);
+  this.generator = new FactoryGenerator(this.model);
 };
 
 /**
@@ -55,9 +55,8 @@ FactoryController.prototype.addCategory = function() {
       if (!name) {  // Exit if cancelled.
         return;
       }
-      this.model.addNewCategoryEntry(name);
-      this.addCategoryToView(name, this.model.getCategoryIdByName(name), true);
-      this.model.setSelectedById(this.model.getCategoryIdByName(name));
+      this.createCategory(name, true);
+      this.model.setSelectedById(category.id);
     }
   }
   // After possibly creating a category, check again if it's the first category.
@@ -68,9 +67,7 @@ FactoryController.prototype.addCategory = function() {
     return;
   }
   // Create category.
-  this.model.addNewCategoryEntry(name);
-  this.addCategoryToView(name, this.model.getCategoryIdByName(name),
-      firstCategory);
+  this.createCategory(name, firstCategory);
   // Switch to category.
   this.switchElement(this.model.getCategoryIdByName(name));
   // Update preview.
@@ -177,6 +174,9 @@ FactoryController.prototype.promptForNewCategoryName = function(promptString) {
  * @param {!string} id ID of tab to be opened, must be valid element ID.
  */
 FactoryController.prototype.switchElement = function(id) {
+  // Disables events while switching so that Blockly delete and create events
+  // don't update the preview repeatedly.
+  Blockly.Events.disable();
   // Caches information to reload or generate xml if switching to/from element.
   // Only saves if a category is selected.
   if (this.model.getSelectedId() != null && id != null) {
@@ -184,6 +184,8 @@ FactoryController.prototype.switchElement = function(id) {
   }
   // Load element.
   this.clearAndLoadElement(id);
+  // Enable Blockly events again.
+  Blockly.Events.enable();
 };
 
 /**
@@ -217,6 +219,8 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
       this.view.disableWorkspace(true);
     }
   }
+  this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
+        (toolboxWorkspace.getAllBlocks()));
   // Update category editing buttons.
   this.view.updateState(this.model.getIndexByElementId
       (this.model.getSelectedId()), this.model.getSelected());
@@ -229,7 +233,7 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
 FactoryController.prototype.exportConfig = function() {
   // Generate XML.
   var configXml = Blockly.Xml.domToPrettyText
-      (this.generator.generateConfigXml());
+      (this.generator.generateConfigXml(this.toolboxWorkspace));
   // Get file name.
   var fileName = prompt("File Name: ");
   if (!fileName) { // If cancelled
@@ -246,7 +250,7 @@ FactoryController.prototype.exportConfig = function() {
  */
 FactoryController.prototype.printConfig = function() {
   window.console.log(Blockly.Xml.domToPrettyText
-      (this.generator.generateConfigXml()));
+      (this.generator.generateConfigXml(this.toolboxWorkspace)));
 };
 
 /**
@@ -262,7 +266,7 @@ FactoryController.prototype.updatePreview = function() {
   // through event handlers.
   Blockly.Events.disable();
   var tree = Blockly.Options.parseToolboxTree
-      (this.generator.generateConfigXml());
+      (this.generator.generateConfigXml(this.toolboxWorkspace));
   // No categories, creates a simple flyout.
   if (tree.getElementsByTagName('category').length == 0) {
     if (this.previewWorkspace.toolbox_) {
@@ -428,6 +432,7 @@ FactoryController.prototype.loadCategory = function() {
         + '. Rename your category and try again.');
     return;
   }
+
   // Copy the standard category in the model.
   var copy = standardCategory.copy();
   this.model.addElementToList(copy);
@@ -482,4 +487,37 @@ FactoryController.prototype.addSeparator = function() {
   // Switch to the separator and update the preview.
   this.switchElement(separator.id);
   this.updatePreview();
+};
+
+/**
+ * Makes the currently selected block a user-generated shadow block. These
+ * blocks are not made into real shadow blocks, but recorded in the model
+ * and visually marked as shadow blocks, allowing the user to move and edit
+ * them (which would be impossible with actual shadow blocks). Updates the
+ * preview when done.
+ *
+ */
+FactoryController.prototype.addShadow = function() {
+  // No block selected to make a shadow block.
+  if (!Blockly.selected) {
+    return;
+  }
+  this.view.markShadowBlock(Blockly.selected);
+  this.model.addShadowBlock(Blockly.selected.id);
+  this.updatePreview();
+};
+
+/**
+ * If the currently selected block is a user-generated shadow block, this
+ * function makes it a normal block again, removing it from the list of
+ * shadow blocks and loading the workspace again. Updates the preview again.
+ *
+ */
+FactoryController.prototype.removeShadow = function() {
+  // No block selected to modify.
+  if (!Blockly.selected) {
+    return;
+  }
+  this.model.removeShadowBlock(Blockly.selected.id);
+  this.view.unmarkShadowBlock(Blockly.selected);
 };

--- a/demos/workspacefactory/factory_generator.js
+++ b/demos/workspacefactory/factory_generator.js
@@ -1,8 +1,9 @@
 /**
  * @fileoverview Generates the configuration xml used to update the preview
  * workspace or print to the console or download to a file. Leverages
- * Blockly.Xml and depends on information in the model and in toolboxWorkspace,
- * by holding references to them.
+ * Blockly.Xml and depends on information in the model (holds a reference).
+ * Depends on a hidden workspace created in the generator to load saved XML in
+ * order to generate toolbox XML.
  *
  * @author Emma Dauterman (evd2014)
  */
@@ -11,19 +12,114 @@
  * Class for a FactoryGenerator
  * @constructor
  */
-FactoryGenerator = function(model, toolboxWorkspace) {
+FactoryGenerator = function(model) {
+  // Model to share information about categories and shadow blocks.
   this.model = model;
-  this.toolboxWorkspace = toolboxWorkspace;
+  // Create hidden workspace to load saved XML to generate toolbox XML.
+  var hiddenBlocks = document.createElement('div');
+  // Generate a globally unique ID for the hidden div element to avoid
+  // collisions.
+  var hiddenBlocksId = Blockly.genUid();
+  hiddenBlocks.id = hiddenBlocksId;
+  hiddenBlocks.style.display = 'none';
+  document.body.appendChild(hiddenBlocks);
+  this.hiddenWorkspace = Blockly.inject(hiddenBlocksId);
 };
 
 /**
- * Encodes workspace for a particular category in a XML DOM element. Very
- * similar to workspaceToDom, but doesn't capture IDs.
+ * Generates the xml for the toolbox or flyout. If there is only a flyout,
+ * only the current blocks are needed, and these are included without
+ * a category. If there are categories, then each category is briefly loaded
+ * to the hidden workspace, the user-generated shadow blocks are set as real
+ * shadow blocks, and the top blocks are used to generate the xml for the flyout
+ * for that category.
+ *
+ * @param {!Blockly.workspace} toolboxWorkspace Toolbox editing workspace where
+ * blocks are added by user to be part of the toolbox.
+ * @return {!Element} XML element representing toolbox or flyout corresponding
+ * to toolbox workspace.
+ */
+FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
+  // Create DOM for XML.
+  var xmlDom = goog.dom.createDom('xml',
+      {
+        'id' : 'toolbox',
+        'style' : 'display:none'
+      });
+  if (!this.model.hasToolbox()) {
+    // Toolbox has no categories. Use XML directly from workspace.
+    this.loadToHiddenWorkspaceAndSave_
+        (Blockly.Xml.workspaceToDom(toolboxWorkspace), xmlDom);
+  } else {
+    // Toolbox has categories.
+    // Assert that selected != null
+    if (!this.model.getSelected()) {
+      throw new Error('Selected is null when the toolbox is empty.');
+    }
+
+    // Capture any changes made by user before generating XML.
+    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+    var xml = this.model.getSelectedXml();
+    var toolboxList = this.model.getToolboxList();
+
+    // Iterate through each category to generate XML for each using the
+    // hidden workspace. Load each category to the hidden workspace to make sure
+    // that all the blocks that are not top blocks are also captured as block
+    // groups in the flyout.
+    for (var i = 0; i < toolboxList.length; i++) {
+      var element = toolboxList[i];
+      if (element.type == ListElement.SEPARATOR) {
+        // If the next element is a separator.
+        var nextElement = goog.dom.createDom('sep');
+        xmlDom.appendChild(sepElement);
+      } else {
+        // If the next element is a category.
+        var nextElement = goog.dom.createDom('category');
+        nextElement.setAttribute('name', element.name);
+        // Add a colour attribute if one exists.
+        if (element.color != null) {
+          nextElement.setAttribute('colour', element.color);
+        }
+        // Add a custom attribute if one exists.
+        if (element.custom != null) {
+          nextElement.setAttribute('custom', element.custom);
+        }
+        // Load that category to hidden workspace, setting user-generated shadow
+        // blocks as real shadow blocks.
+        this.loadToHiddenWorkspaceAndSave_(element.xml, nextElement);
+      }
+      xmlDom.appendChild(nextElement);
+    }
+  }
+  return xmlDom;
+ };
+
+/**
+ * Load the given XML to the hidden workspace, set any user-generated shadow
+ * blocks to be actual shadow blocks, then append the XML from the workspace
+ * to the DOM element passed in.
+ * @private
+ *
+ * @param {!Element} xml The XML to be loaded to the hidden workspace.
+ * @param {!Element} dom The DOM element to append the generated XML to.
+ */
+FactoryGenerator.prototype.loadToHiddenWorkspaceAndSave_ = function(xml, dom) {
+  this.hiddenWorkspace.clear();
+  Blockly.Xml.domToWorkspace(xml, this.hiddenWorkspace);
+  this.setShadowBlocksInHiddenWorkspace_();
+  this.appendHiddenWorkspaceToDom_(dom);
+}
+
+ /**
+ * Encodes blocks in the hidden workspace in a XML DOM element. Very
+ * similar to workspaceToDom, but doesn't capture IDs. Uses the top-level
+ * blocks loaded in hiddenWorkspace.
+ * @private
  *
  * @param {!Element} xmlDom Tree of XML elements to be appended to.
- * @param {!Array.<!Blockly.Block>} topBlocks top level blocks to add to xmlDom
  */
-FactoryGenerator.prototype.categoryWorkspaceToDom = function(xmlDom, blocks) {
+FactoryGenerator.prototype.appendHiddenWorkspaceToDom_ = function(xmlDom) {
+  var blocks = this.hiddenWorkspace.getTopBlocks();
   for (var i = 0, block; block = blocks[i]; i++) {
     var blockChild = Blockly.Xml.blockToDom(block);
     blockChild.removeAttribute('id');
@@ -32,67 +128,17 @@ FactoryGenerator.prototype.categoryWorkspaceToDom = function(xmlDom, blocks) {
 };
 
 /**
- * Generates the xml for the toolbox or flyout. If there is only a flyout,
- * only the current blocks are needed, and these are included without
- * a category. If there are categories, then each category is briefly loaded
- * and the top blocks are used to generate the xml for the flyout for that
- * category.
+ * Sets the user-generated shadow blocks loaded into hiddenWorkspace to be
+ * actual shadow blocks. This is done so that blockToDom records them as
+ * shadow blocks instead of regular blocks.
+ * @private
  *
- * @return {!Element} XML element representing toolbox or flyout corresponding
- * to toolbox workspace.
  */
-FactoryGenerator.prototype.generateConfigXml = function() {
-  // Create DOM for XML.
-  var xmlDom = goog.dom.createDom('xml',
-      {
-        'id' : 'toolbox',
-        'style' : 'display:none'
-      });
-  // If no categories, use XML directly from workspace
-  if (!this.model.hasToolbox()) {
-    this.categoryWorkspaceToDom(xmlDom, this.toolboxWorkspace.getTopBlocks());
-  }
-  else {
-    // Assert that selected != null
-    if (!this.model.getSelected()) {
-      throw new Error('Selected is null when there are categories');
+FactoryGenerator.prototype.setShadowBlocksInHiddenWorkspace_ = function() {
+  var blocks = this.hiddenWorkspace.getAllBlocks();
+  for (var i = 0; i < blocks.length; i++) {
+    if (this.model.isShadowBlock(blocks[i].id)) {
+      blocks[i].setShadow(true);
     }
-    // Capture any changes made by user before generating xml.
-    this.model.getSelected().saveFromWorkspace(this.toolboxWorkspace);
-    var toolboxList = this.model.getToolboxList();
-    // Iterate through each category to generate XML for each. Load each
-    // category to make sure that all the blocks that are not top blocks are
-    // also captured as block groups in the flyout.
-    for (var i = 0; i < toolboxList.length; i++) {
-      // Create category DOM element.
-      var element = toolboxList[i];
-      if (element.type == ListElement.TYPE_SEPARATOR) {
-        var sepElement = goog.dom.createDom('sep');
-        xmlDom.appendChild(sepElement);
-      } else {
-        var categoryElement = goog.dom.createDom('category');
-        categoryElement.setAttribute('name', element.name);
-        // Add a colour attribute if one exists.
-        if (element.color != null) {
-          categoryElement.setAttribute('colour', element.color);
-        }
-        // Add a custom attribute if one exists.
-        if (element.custom != null) {
-          categoryElement.setAttribute('custom', element.custom);
-        }
-        // Load that category to workspace.
-        this.toolboxWorkspace.clear();
-        Blockly.Xml.domToWorkspace(element.xml, this.toolboxWorkspace);
-        // Generate XML for that category, append to DOM for all XML.
-        this.categoryWorkspaceToDom(categoryElement,
-            this.toolboxWorkspace.getTopBlocks());
-        xmlDom.appendChild(categoryElement);
-      }
-    }
-    // Load category user was working on.
-    this.toolboxWorkspace.clear();
-    Blockly.Xml.domToWorkspace(this.model.getSelectedXml(),
-        this.toolboxWorkspace);
   }
-  return xmlDom;
- };
+};

--- a/demos/workspacefactory/factory_generator.js
+++ b/demos/workspacefactory/factory_generator.js
@@ -27,12 +27,8 @@ FactoryGenerator = function(model) {
 };
 
 /**
- * Generates the xml for the toolbox or flyout. If there is only a flyout,
- * only the current blocks are needed, and these are included without
- * a category. If there are categories, then each category is briefly loaded
- * to the hidden workspace, the user-generated shadow blocks are set as real
- * shadow blocks, and the top blocks are used to generate the xml for the flyout
- * for that category.
+ * Generates the xml for the toolbox or flyout with information from
+ * toolboxWorkspace and the model. Uses the hiddenWorkspace to generate XML.
  *
  * @param {!Blockly.workspace} toolboxWorkspace Toolbox editing workspace where
  * blocks are added by user to be part of the toolbox.

--- a/demos/workspacefactory/factory_model.js
+++ b/demos/workspacefactory/factory_model.js
@@ -3,8 +3,9 @@
  * in workspace factory. Each list element is either a separator or a category,
  * and each category stores its name, XML to load that category, color,
  * custom tags, and a unique ID making it possible to change category names and
- * move categories easily. Also keeps track of the currently selected list
- * element.
+ * move categories easily. Keeps track of the currently selected list
+ * element. Also keeps track of all the user-created shadow blocks and
+ * manipulates them as necessary.
  *
  * @author Emma Dauterman (evd2014)
  */
@@ -16,6 +17,8 @@
 FactoryModel = function() {
   // Ordered list of ListElement objects.
   this.toolboxList = [];
+  // Array of block IDs for all user created shadow blocks.
+  this.shadowBlocks = [];
   // String name of current selected list element, null if no list elements.
   this.selected = null;
   // Boolean for if a Variable category has been added.
@@ -80,10 +83,12 @@ FactoryModel.prototype.hasToolbox = function() {
  * @param {!ListElement} element The element to be added to the list.
  */
 FactoryModel.prototype.addElementToList = function(element) {
+  // Update state if the copied category has a custom tag.
   this.hasVariableCategory = element.custom == 'VARIABLE' ? true :
       this.hasVariableCategory;
   this.hasProcedureCategory = element.custom == 'PROCEDURE' ? true :
       this.hasProcedureCategory;
+  // Add element to toolboxList.
   this.toolboxList.push(element);
 };
 
@@ -172,8 +177,9 @@ FactoryModel.prototype.setSelectedById = function(id) {
  *
  * @param {!string} id The ID of list element to search for.
  * @return {int} The index of the list element in toolboxList, or -1 if it
- *     doesn't exist.
+ * doesn't exist.
  */
+
 FactoryModel.prototype.getIndexByElementId = function(id) {
   for (var i = 0; i < this.toolboxList.length; i++) {
     if (this.toolboxList[i].id == id) {
@@ -248,7 +254,64 @@ FactoryModel.prototype.getCategoryIdByName = function(name) {
 };
 
 /**
- * Class for a ListElement
+ * Adds a shadow block to the list of shadow blocks.
+ *
+ * @param {!string} blockId The unique ID of block to be added.
+ */
+FactoryModel.prototype.addShadowBlock = function(blockId) {
+  this.shadowBlocks.push(blockId);
+};
+
+/**
+ * Removes a shadow block ID from the list of shadow block IDs if that ID is
+ * in the list.
+ *
+ * @param {!string} blockId The unique ID of block to be removed.
+ */
+FactoryModel.prototype.removeShadowBlock = function(blockId) {
+  for (var i = 0; i < this.shadowBlocks.length; i++) {
+    if (this.shadowBlocks[i] == blockId) {
+      this.shadowBlocks.splice(i, 1);
+      return;
+    }
+  }
+};
+
+/**
+ * Determines if a block is a shadow block given a unique block ID.
+ *
+ * @param {!string} blockId The unique ID of the block to examine.
+ */
+FactoryModel.prototype.isShadowBlock = function(blockId) {
+  for (var i = 0; i < this.shadowBlocks.length; i++) {
+    if (this.shadowBlocks[i] == blockId) {
+      return true;
+    }
+  }
+  return false;
+};
+
+/**
+ * Given a set of blocks currently loaded, returns all blocks in the workspace
+ * that are user generated shadow blocks.
+ *
+ * @param {!<Blockly.Block>} blocks Array of blocks currently loaded.
+ * @return {!<Blockly.Block>} Array of user-generated shadow blocks currently
+ * loaded.
+ */
+FactoryModel.prototype.getShadowBlocksInWorkspace = function(workspaceBlocks) {
+  var shadowsInWorkspace = [];
+  for (var i = 0; i < workspaceBlocks.length; i++) {
+    if (this.isShadowBlock(workspaceBlocks[i].id)) {
+      shadowsInWorkspace.push(workspaceBlocks[i]);
+    }
+  }
+  return shadowsInWorkspace;
+};
+
+
+/**
+ * Class for a ListElement.
  * @constructor
  */
 ListElement = function(type, opt_name) {
@@ -264,6 +327,7 @@ ListElement = function(type, opt_name) {
   // Stores a custom tag, if necessary. Null if no custom tag or separator.
   this.custom = null;
 };
+
 // List element types.
 ListElement.TYPE_CATEGORY = 'category';
 ListElement.TYPE_SEPARATOR = 'separator';
@@ -318,6 +382,8 @@ ListElement.prototype.changeColor = function (color) {
  */
 ListElement.prototype.copy = function() {
   copy = new ListElement(this.type);
+  // Generate a unique ID for the element.
+  copy.id = Blockly.genUid();
   // Copy all attributes except ID.
   copy.name = this.name;
   copy.xml = this.xml;

--- a/demos/workspacefactory/factory_view.js
+++ b/demos/workspacefactory/factory_view.js
@@ -81,7 +81,7 @@ FactoryView.prototype.deleteElementRow = function(id, index) {
  */
 FactoryView.prototype.updateState = function(selectedIndex, selected) {
   // Disable/enable editing buttons as necessary.
-  document.getElementById('button_edit').disabled = selectedIndex < 0 ||
+  document.getElementById('button_editCategory').disabled = selectedIndex < 0 ||
       selected.type != ListElement.TYPE_CATEGORY;
   document.getElementById('button_remove').disabled = selectedIndex < 0;
   document.getElementById('button_up').disabled =
@@ -249,4 +249,44 @@ FactoryView.prototype.disableWorkspace = function(disable) {
 FactoryView.prototype.shouldDisableWorkspace = function(category) {
   return category != null && (category.type == ListElement.SEPARATOR ||
       category.custom == 'VARIABLE' || category.custom == 'PROCEDURE');
+};
+
+/**
+ * Given a set of blocks currently loaded user-generated shadow blocks, visually
+ * marks them without making them actual shadow blocks (allowing them to still
+ * be editable and movable).
+ *
+ * @param {!<Blockly.Block>} blocks Array of user-generated shadow blocks
+ * currently loaded.
+ */
+FactoryView.prototype.markShadowBlocks = function(blocks) {
+  for (var i = 0; i < blocks.length; i++) {
+    this.markShadowBlock(blocks[i]);
+  }
+};
+
+/**
+ * Visually marks a user-generated shadow block as a shadow block in the
+ * workspace without making the block an actual shadow block (allowing it
+ * to be moved and edited).
+ *
+ * @param {!Blockly.Block} block The block that should be marked as a shadow
+ *    block (must be rendered).
+ */
+FactoryView.prototype.markShadowBlock = function(block) {
+  // Add Blockly CSS for user-generated shadow blocks.
+  Blockly.addClass_(block.svgGroup_, 'shadowBlock');
+};
+
+/**
+ * Removes visual marking for a shadow block given a rendered block.
+ *
+ * @param {!Blockly.Block} block The block that should be unmarked as a shadow
+ *    block (must be rendered).
+ */
+FactoryView.prototype.unmarkShadowBlock = function(block) {
+  // Remove Blockly CSS for user-generated shadow blocks.
+  if (Blockly.hasClass_(block.svgGroup_, 'shadowBlock')) {
+    Blockly.removeClass_(block.svgGroup_, 'shadowBlock');
+  }
 };

--- a/demos/workspacefactory/index.html
+++ b/demos/workspacefactory/index.html
@@ -48,6 +48,7 @@ goog.require('goog.ui.ColorPicker');
       <td id="tab_help">Your categories will appear here</td>
     </table>
     <p>&nbsp;</p>
+
     <div class='dropdown'>
     <button id="button_add">+</button>
     <div id="dropdown_add" class="dropdown-content">
@@ -56,17 +57,31 @@ goog.require('goog.ui.ColorPicker');
       <a id='dropdown_separator'>Separator</a>
     </div>
     </div>
+
     <button id="button_remove">-</button>
+
+    <button id="button_up">&#8593;</button>
+    <button id="button_down">&#8595;</button>
+
     <p>&nbsp;</p>
     <div class='dropdown'>
-    <button id="button_edit">Edit</button>
-    <div id="dropdown_edit" class="dropdown-content">
+    <button id="button_editCategory">Edit Category</button>
+    <div id="dropdown_editCategory" class="dropdown-content">
       <a id='dropdown_name'>Name</a>
       <a id='dropdown_color'>Color</a>
     </div>
     </div>
-    <button id="button_up">&#8593;</button>
-    <button id="button_down">&#8595;</button>
+
+    <div class='dropdown'>
+    <button id="button_editShadow">Edit Block</button>
+    <div id="dropdown_editShadowAdd" class="dropdown-content">
+      <a id='dropdown_addShadow'>Add Shadow</a>
+    </div>
+    <div id="dropdown_editShadowRemove" class="dropdown-content">
+      <a id='dropdown_removeShadow'>Remove Shadow</a>
+    </div>
+    </div>
+
   </aside>
 </section>
 
@@ -500,12 +515,39 @@ goog.require('goog.ui.ColorPicker');
   var downWrapper = function() {
     controller.moveElement(1);
   };
-  var editWrapper = function() {
-    document.getElementById('dropdown_edit').classList.toggle("show");
+  var editCategoryWrapper = function() {
+    document.getElementById('dropdown_editCategory').classList.toggle("show");
   };
   var nameWrapper = function() {
     controller.changeCategoryName();
-    document.getElementById('dropdown_edit').classList.remove("show");
+    document.getElementById('dropdown_editCategory').classList.remove("show");
+  };
+  var shadowAddWrapper = function() {
+    controller.addShadow();
+    document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+  };
+    var shadowRemoveWrapper = function() {
+    controller.removeShadow();
+    document.getElementById('dropdown_editShadowRemove').classList.remove("show");
+  };
+  var editShadowWrapper = function() {
+    // Allow the user to make a block a shadow block only if a block is selected
+    // and the block has a surrounding parent (necessary for the block to be
+    // a valid shadow block).
+    if (Blockly.selected && Blockly.selected.getSurroundParent() != null) {
+      // If the block is not a shadow block, let the user make it a shadow block.
+      // Use toggle instead of add so that the user can click the button again
+      // to make the dropdown disappear without clicking one of the options.
+      if (!controller.model.isShadowBlock(Blockly.selected.id)) {
+
+        document.getElementById('dropdown_editShadowRemove').classList.remove("show");
+        document.getElementById('dropdown_editShadowAdd').classList.toggle("show");
+      // If the block is a shadow block, let the user make it a normal block.
+      } else {
+        document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+        document.getElementById('dropdown_editShadowRemove').classList.toggle("show");
+      }
+    }
   };
 
   document.getElementById('button_add').addEventListener
@@ -526,10 +568,16 @@ goog.require('goog.ui.ColorPicker');
       ('click', upWrapper);
   document.getElementById('button_down').addEventListener
       ('click', downWrapper);
-  document.getElementById('button_edit').addEventListener
-      ('click', editWrapper);
+  document.getElementById('button_editCategory').addEventListener
+      ('click', editCategoryWrapper);
+  document.getElementById('button_editShadow').addEventListener
+      ('click', editShadowWrapper);
   document.getElementById('dropdown_name').addEventListener
       ('click', nameWrapper);
+  document.getElementById('dropdown_editShadowAdd').addEventListener
+      ('click', shadowAddWrapper);
+    document.getElementById('dropdown_editShadowRemove').addEventListener
+      ('click', shadowRemoveWrapper);
 
   // Create color picker with specific set of Blockly colors.
   var colorPicker = new goog.ui.ColorPicker();
@@ -541,22 +589,41 @@ goog.require('goog.ui.ColorPicker');
   popupPicker.setFocusable(true);
   goog.events.listen(popupPicker, 'change', function(e) {
         controller.changeSelectedCategoryColor(popupPicker.getSelectedColor());
-        document.getElementById('dropdown_edit').classList.remove("show");
+        document.getElementById('dropdown_editCategory').classList.remove
+            ("show");
       });
 
   // Disable category editing buttons until categories are created.
   document.getElementById('button_remove').disabled = true;
-  document.getElementById('button_edit').disabled = true;
   document.getElementById('button_up').disabled = true;
   document.getElementById('button_down').disabled = true;
+  document.getElementById('button_editCategory').disabled = true;
+  document.getElementById('button_editShadow').disabled = true;
 
-  // Listen for Blockly move and delete events to update preview.
-  // Not listening for Blockly create events because causes the user to drop
-  // blocks when dragging them into workspace. Could cause problems if
-  // blocks loaded into workspace directly without calling updatePreview.
   toolboxWorkspace.addChangeListener(function(e) {
+    // Listen for Blockly move and delete events to update preview.
+    // Not listening for Blockly create events because causes the user to drop
+    // blocks when dragging them into workspace. Could cause problems if ever load
+    // blocks into workspace directly without calling updatePreview.
     if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
       controller.updatePreview();
+    }
+    // Listen for Blockly UI events to correctly enable the "Edit Block" button.
+    // Only enable "Edit Block" when a block is selected and it has a surrounding
+    // parent, meaning it is nested in another block (blocks that are not
+    // nested in parents cannot be shadow blocks).
+    // TODO(evd2014): Listen for when the user has moved a block to be nested inside
+    // another (currently have to unselect and reselect that block).
+    if (e.type == Blockly.Events.MOVE || (e.type == Blockly.Events.UI &&
+        e.element == 'selected')) {
+      var selected = toolboxWorkspace.getBlockById(e.newValue);
+      if (selected != null && selected.getSurroundParent() != null) {
+        document.getElementById('button_editShadow').disabled = false;
+      } else {
+        document.getElementById('button_editShadow').disabled = true;
+        document.getElementById('dropdown_editShadowRemove').classList.remove("show");
+        document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+      }
     }
   });
 </script>

--- a/demos/workspacefactory/style.css
+++ b/demos/workspacefactory/style.css
@@ -190,3 +190,13 @@ td {
 .show {
   display: block;
 }
+
+.shadowBlock>.blocklyPath {
+  fill-opacity: .5;
+  stroke-opacity: .5;
+}
+
+.shadowBlock>.blocklyPathLight,
+.shadowBlock>.blocklyPathDark {
+  display: none;
+}


### PR DESCRIPTION
Allows the user to generate shadow blocks that are visually marked as shadow blocks in the workspace (without being actual blocks) and show up as real shadow in the toolbox XML. The user can select the block, and then, if it could be a valid shadow block (meaning that a block is selected and it is nested in another block), they have the option to make it a shadow block (if it is not a user-generated shadow block) or make it a normal block again (if it is a user-generated shadow block). The user-generated shadow blocks are colored black in the view. 
![add shadow](https://cloud.githubusercontent.com/assets/18580768/17264625/282487c4-559d-11e6-8c38-8b1126ae12f6.png)
![remove shadow](https://cloud.githubusercontent.com/assets/18580768/17264627/2a3c7562-559d-11e6-8a65-6a029ac494d6.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/28)

<!-- Reviewable:end -->
