### PR TITLE
Workspace Factory #9: Import Toolbox XML

### DIFF
--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -496,6 +496,7 @@ FactoryController.prototype.importFile = function(file) {
   if (!file) {
     return;
   }
+
   var reader = new FileReader();
   // To be executed when the reader has read the file.
   reader.onload = function() {
@@ -508,6 +509,7 @@ FactoryController.prototype.importFile = function(file) {
       alert('Cannot load XML from file.');
     }
   }
+
   // Read the file.
   reader.readAsText(file);
 };
@@ -536,7 +538,7 @@ FactoryController.prototype.importFromTree_ = function(tree) {
     // Categories/separators present.
     for (var i = 0, item; item = tree.children[i]; i++) {
       if (item.tagName == 'category') {
-      // If the element is a category, create a new category and switch to it.
+        // If the element is a category, create a new category and switch to it.
         this.createCategory(item.getAttribute('name'), false);
         var category = this.model.getElementByIndex(i);
         this.switchElement(category.id);
@@ -556,7 +558,7 @@ FactoryController.prototype.importFromTree_ = function(tree) {
           category.changeColor(item.color);
         }
       } else {
-      // If the element is a separator, add the separator and switch to it.
+        // If the element is a separator, add the separator and switch to it.
         this.addSeparator();
         this.switchElement(this.model.getElementByIndex(i).id);
       }

--- a/demos/workspacefactory/factory_model.js
+++ b/demos/workspacefactory/factory_model.js
@@ -252,7 +252,7 @@ FactoryModel.prototype.getCategoryIdByName = function(name) {
  */
 FactoryModel.prototype.clearToolboxList = function() {
   this.toolboxList = [];
-  // TODO: When merge changes, also clear shadowList.
+  // TODO(evd2014): When merge changes, also clear shadowList.
 };
 
 /**

--- a/demos/workspacefactory/factory_model.js
+++ b/demos/workspacefactory/factory_model.js
@@ -248,6 +248,14 @@ FactoryModel.prototype.getCategoryIdByName = function(name) {
 };
 
 /**
+ * Clears the toolbox list, deleting all ListElements.
+ */
+FactoryModel.prototype.clearToolboxList = function() {
+  this.toolboxList = [];
+  // TODO: When merge changes, also clear shadowList.
+};
+
+/**
  * Class for a ListElement
  * @constructor
  */
@@ -282,6 +290,7 @@ ListElement.prototype.saveFromWorkspace = function(workspace) {
   }
   this.xml = Blockly.Xml.workspaceToDom(workspace);
 };
+
 
 /**
  * Changes the name of a category object given a new name. Returns if

--- a/demos/workspacefactory/factory_view.js
+++ b/demos/workspacefactory/factory_view.js
@@ -59,13 +59,24 @@ FactoryView.prototype.deleteElementRow = function(id, index) {
   var table = document.getElementById('categoryTable');
   var count = table.rows.length;
   table.deleteRow(index);
+
   // If last category removed, add category help text and disable category
   // buttons.
-  if (count == 1) {
+  this.addEmptyCategoryMessage();
+};
+
+/**
+ * If there are no toolbox elements created, adds a help message to show
+ * where categories will appear. Should be called when deleting list elements
+ * in case the last element is deleted.
+ */
+FactoryView.prototype.addEmptyCategoryMessage = function() {
+  var table = document.getElementById('categoryTable');
+  if (table.rows.length == 0) {
     var row = table.insertRow(0);
     row.textContent = 'Your categories will appear here';
   }
-};
+}
 
 /**
  * Given the index of the currently selected element, updates the state of
@@ -249,4 +260,16 @@ FactoryView.prototype.disableWorkspace = function(disable) {
 FactoryView.prototype.shouldDisableWorkspace = function(category) {
   return category != null && (category.type == ListElement.SEPARATOR ||
       category.custom == 'VARIABLE' || category.custom == 'PROCEDURE');
+};
+/*
+ * Removes all categories and separators in the view. Clears the tabMap to
+ * reflect this.
+ */
+FactoryView.prototype.clearToolboxTabs = function() {
+  this.tabMap = [];
+  var oldCategoryTable = document.getElementById('categoryTable');
+  var newCategoryTable = document.createElement('table');
+  newCategoryTable.id = 'categoryTable';
+  oldCategoryTable.parentElement.replaceChild(newCategoryTable,
+      oldCategoryTable);
 };

--- a/demos/workspacefactory/index.html
+++ b/demos/workspacefactory/index.html
@@ -30,8 +30,11 @@ goog.require('goog.ui.ColorPicker');
   <tr>
     <td>
       <p>
-        <button id="button_export">Export Config</button>
-        <button id="button_print">Print Config</button>
+        <input type="file" id="input_import" class="inputfile"></input>
+        <label for="input_import">Import</label>
+        <button id="button_export">Export</button>
+        <button id="button_print">Print</button>
+        <button id="button_clear">Clear</button>
       </p>
     </td>
   </tr>
@@ -507,6 +510,12 @@ goog.require('goog.ui.ColorPicker');
     controller.changeCategoryName();
     document.getElementById('dropdown_edit').classList.remove("show");
   };
+  var importWrapper = function(event) {
+    controller.importFile(event.target.files[0]);
+  };
+  var clearWrapper = function() {
+    controller.clear();
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -530,6 +539,10 @@ goog.require('goog.ui.ColorPicker');
       ('click', editWrapper);
   document.getElementById('dropdown_name').addEventListener
       ('click', nameWrapper);
+  document.getElementById('input_import').addEventListener
+      ('change', importWrapper);
+  document.getElementById('button_clear').addEventListener
+      ('click', clearWrapper);
 
   // Create color picker with specific set of Blockly colors.
   var colorPicker = new goog.ui.ColorPicker();
@@ -559,5 +572,6 @@ goog.require('goog.ui.ColorPicker');
       controller.updatePreview();
     }
   });
+
 </script>
 </html>

--- a/demos/workspacefactory/standard_categories.js
+++ b/demos/workspacefactory/standard_categories.js
@@ -3,6 +3,7 @@
  * standard Blockly categories into the user's toolbox. The map is keyed by
  * the lower case name of the category, and contains the Category object for
  * that particular category.
+ * TODO(evd2014): Remove XY attributes and layout using cleanUp() instead.
  *
  * @author Emma Dauterman (evd2014)
  */

--- a/demos/workspacefactory/style.css
+++ b/demos/workspacefactory/style.css
@@ -63,6 +63,33 @@ button:hover:not(:disabled)>* {
   opacity: 1;
 }
 
+label {
+  border-radius: 4px;
+  border: 1px solid #ddd;
+  background-color: #eee;
+  color: #000;
+  font-size: large;
+  margin: 0 5px;
+  padding: 10px;
+}
+
+label:hover:not(:disabled) {
+  box-shadow: 2px 2px 5px #888;
+}
+
+label:disabled {
+  opacity: .6;
+}
+
+label>* {
+  opacity: .6;
+  vertical-align: text-bottom;
+}
+
+label:hover:not(:disabled)>* {
+  opacity: 1;
+}
+
 table {
   border: none;
   border-collapse: collapse;
@@ -73,6 +100,15 @@ table {
 td {
   padding: 0;
   vertical-align: top;
+}
+
+.inputfile {
+  height: 0;
+  opacity: 0;
+  overflow: hidden;
+  position: absolute;
+  width: 0;
+  z-index: -1;
 }
 
 #toolbox_section {


### PR DESCRIPTION
Allows user to choose a local file containing toolbox XML and load it into the workspace factory editing space to continue editing it. If the user does not choose a valid XML file, it prints an error message. 

Also adds a "Clear" button to entirely clear the workspace factory editing space. This was trivial to add because it is necessary to clear before loading a toolbox from a file. 
![import button](https://cloud.githubusercontent.com/assets/18580768/17312955/4a6664da-580c-11e6-8d6a-3705765d3c8c.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/29)

<!-- Reviewable:end -->
