### PR TITLE
Workspace Factory #11: Convert to user-generated shadow blocks on import

### DIFF
--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -199,16 +199,20 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
   if (this.model.getSelectedId() != null && id != null) {
     this.view.setCategoryTabSelection(this.model.getSelectedId(), false);
   }
+
   // If switching from a separator, enable workspace in view.
   if (this.model.getSelectedId() != null && this.model.getSelected().type ==
       ListElement.TYPE_SEPARATOR) {
     this.view.disableWorkspace(false);
   }
+
   // Set next category.
   this.model.setSelectedById(id);
+
   // Clear workspace.
   this.toolboxWorkspace.clear();
   this.toolboxWorkspace.clearUndo();
+
   // Loads next category if switching to an element.
   if (id != null) {
     this.view.setCategoryTabSelection(id, true);
@@ -219,10 +223,12 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
       this.view.disableWorkspace(true);
     }
   }
+
+  // Mark all shadow blocks laoded and order blocks as if shown in a flyout.
   this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
         (toolboxWorkspace.getAllBlocks()));
-  // Order blocks as if shown in a flyout.
   this.toolboxWorkspace.cleanUp_();
+
   // Update category editing buttons.
   this.view.updateState(this.model.getIndexByElementId
       (this.model.getSelectedId()), this.model.getSelected());

--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -440,7 +440,8 @@ FactoryController.prototype.loadCategory = function() {
   this.model.addElementToList(copy);
 
   // Update the copy in the view.
-  var tab = this.view.addCategoryRow(copy.name, copy.id, this.model.getSelected() == null);
+  var tab = this.view.addCategoryRow(copy.name, copy.id,
+      this.model.getSelected() == null);
   this.addClickToSwitch(tab, copy.id);
   // Color the category tab in the view.
   if (copy.color) {
@@ -448,6 +449,8 @@ FactoryController.prototype.loadCategory = function() {
   }
   // Switch to loaded category.
   this.switchElement(copy.id);
+  // Convert actual shadow blocks to user-generated shadow blocks.
+  this.convertShadowBlocks_();
   // Update preview.
   this.updatePreview();
 };
@@ -542,6 +545,8 @@ FactoryController.prototype.importFromTree_ = function(tree) {
     // Load all the blocks into a single category evenly spaced.
     Blockly.Xml.domToWorkspace(tree, this.toolboxWorkspace);
     this.toolboxWorkspace.cleanUp_();
+    // Convert actual shadow blocks to user-generated shadow blocks.
+    this.convertShadowBlocks_();
     // Add message to denote empty category.
     this.view.addEmptyCategoryMessage();
   } else {
@@ -563,6 +568,8 @@ FactoryController.prototype.importFromTree_ = function(tree) {
         // TODO(evd2014): Change to cleanUp once cleanUp_ is made public in
         // master.
         this.toolboxWorkspace.cleanUp_();
+        // Convert actual shadow blocks to user-generated shadow blocks.
+        this.convertShadowBlocks_();
         // Set category color.
         if (item.color) {
           category.changeColor(item.color);
@@ -622,4 +629,23 @@ FactoryController.prototype.removeShadow = function() {
   }
   this.model.removeShadowBlock(Blockly.selected.id);
   this.view.unmarkShadowBlock(Blockly.selected);
+  this.updatePreview();
+};
+
+/**
+ * Call when importing XML containing real shadow blocks. This function turns
+ * all real shadow blocks loaded in the workspaceinto user-generated shadow
+ * blocks, meaning they are marked as shadow blocks by the model and appear as
+ * shadow blocks in the view but are still editable and movable.
+ * @private
+ */
+FactoryController.prototype.convertShadowBlocks_ = function() {
+  var blocks = this.toolboxWorkspace.getAllBlocks();
+  for (var i = 0, block; block = blocks[i]; i++) {
+    if (block.isShadow()) {
+      block.setShadow(false);
+      this.model.addShadowBlock(block.id);
+      this.view.markShadowBlock(block);
+    }
+  }
 };

--- a/demos/workspacefactory/factory_controller.js
+++ b/demos/workspacefactory/factory_controller.js
@@ -545,8 +545,10 @@ FactoryController.prototype.importFromTree_ = function(tree) {
     // Load all the blocks into a single category evenly spaced.
     Blockly.Xml.domToWorkspace(tree, this.toolboxWorkspace);
     this.toolboxWorkspace.cleanUp_();
+
     // Convert actual shadow blocks to user-generated shadow blocks.
     this.convertShadowBlocks_();
+
     // Add message to denote empty category.
     this.view.addEmptyCategoryMessage();
   } else {
@@ -568,8 +570,10 @@ FactoryController.prototype.importFromTree_ = function(tree) {
         // TODO(evd2014): Change to cleanUp once cleanUp_ is made public in
         // master.
         this.toolboxWorkspace.cleanUp_();
+
         // Convert actual shadow blocks to user-generated shadow blocks.
         this.convertShadowBlocks_();
+
         // Set category color.
         if (item.color) {
           category.changeColor(item.color);
@@ -634,7 +638,7 @@ FactoryController.prototype.removeShadow = function() {
 
 /**
  * Call when importing XML containing real shadow blocks. This function turns
- * all real shadow blocks loaded in the workspaceinto user-generated shadow
+ * all real shadow blocks loaded in the workspace into user-generated shadow
  * blocks, meaning they are marked as shadow blocks by the model and appear as
  * shadow blocks in the view but are still editable and movable.
  * @private


### PR DESCRIPTION
When importing categories (either loading a standard category or importing XML for the toolbox), convert all actual shadow blocks to user-generated shadow blocks (look like shadow blocks, but information stored about them in the model and they can be moved and edited). Allows the user to be able to treat shadow blocks consistently when editing their toolbox.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/34)

<!-- Reviewable:end -->
