### PR TITLE
Workspace Factory #12: User-generated Shadow Block Validation

### DIFF
--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -543,7 +543,7 @@ goog.require('goog.ui.ColorPicker');
     if (Blockly.selected) {
       // Can only edit blocks when a block is selected.
 
-      if (!controller.model.isShadowBlock(Blockly.selected.id) && Blockly.selected.getSurroundParent() != null) {
+      if (!controller.isUserGenShadowBlock(Blockly.selected.id) && Blockly.selected.getSurroundParent() != null) {
         // If a block is selected that could be a valid shadow block (not a shadow block,
         // has a surrounding parent), let the user make it a shadow block.
         // Use toggle instead of add so that the user can click the button again
@@ -652,7 +652,7 @@ goog.require('goog.ui.ColorPicker');
         document.getElementById('button_editShadow').disabled = false;
         Blockly.selected.setWarningText(null);
       } else {
-        if (selected != null && controller.model.isShadowBlock(selected.id)) {
+        if (selected != null && controller.isUserGenShadowBlock(selected.id)) {
 
         // Provide warning if shadow block is moved and is no longer a valid shadow block.
           Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -532,21 +532,26 @@ goog.require('goog.ui.ColorPicker');
     var shadowRemoveWrapper = function() {
     controller.removeShadow();
     document.getElementById('dropdown_editShadowRemove').classList.remove("show");
+    // If turning invalid shadow block back to normal block, remove warning and disable
+    // block editing privileges.
+    Blockly.selected.setWarningText(null);
+    if (!Blockly.selected.getSurroundParent()) {
+      document.getElementById('button_editShadow').disabled = true;
+    }
   };
   var editShadowWrapper = function() {
-    // Allow the user to make a block a shadow block only if a block is selected
-    // and the block has a surrounding parent (necessary for the block to be
-    // a valid shadow block).
-    if (Blockly.selected && Blockly.selected.getSurroundParent() != null) {
-      // If the block is not a shadow block, let the user make it a shadow block.
-      // Use toggle instead of add so that the user can click the button again
-      // to make the dropdown disappear without clicking one of the options.
-      if (!controller.model.isShadowBlock(Blockly.selected.id)) {
+    if (Blockly.selected) {
+      // Can only edit blocks when a block is selected.
 
+      if (!controller.model.isShadowBlock(Blockly.selected.id) && Blockly.selected.getSurroundParent() != null) {
+        // If a block is selected that could be a valid shadow block (not a shadow block,
+        // has a surrounding parent), let the user make it a shadow block.
+        // Use toggle instead of add so that the user can click the button again
+        // to make the dropdown disappear without clicking one of the options.
         document.getElementById('dropdown_editShadowRemove').classList.remove("show");
         document.getElementById('dropdown_editShadowAdd').classList.toggle("show");
-      // If the block is a shadow block, let the user make it a normal block.
       } else {
+        // If the block is a shadow block, let the user make it a normal block.
         document.getElementById('dropdown_editShadowAdd').classList.remove("show");
         document.getElementById('dropdown_editShadowRemove').classList.toggle("show");
       }
@@ -621,21 +626,38 @@ goog.require('goog.ui.ColorPicker');
     if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
       controller.updatePreview();
     }
+
     // Listen for Blockly UI events to correctly enable the "Edit Block" button.
     // Only enable "Edit Block" when a block is selected and it has a surrounding
     // parent, meaning it is nested in another block (blocks that are not
     // nested in parents cannot be shadow blocks).
-    // TODO(evd2014): Listen for when the user has moved a block to be nested inside
-    // another (currently have to unselect and reselect that block).
     if (e.type == Blockly.Events.MOVE || (e.type == Blockly.Events.UI &&
         e.element == 'selected')) {
-      var selected = toolboxWorkspace.getBlockById(e.newValue);
+      var selected = Blockly.selected;
+
       if (selected != null && selected.getSurroundParent() != null) {
+
+        // A valid shadow block is selected. Enable block editing and remove warnings.
         document.getElementById('button_editShadow').disabled = false;
+        Blockly.selected.setWarningText(null);
       } else {
-        document.getElementById('button_editShadow').disabled = true;
-        document.getElementById('dropdown_editShadowRemove').classList.remove("show");
-        document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+        if (selected != null && controller.model.isShadowBlock(selected.id)) {
+
+        // Provide warning if shadow block is moved and is no longer a valid shadow block.
+          Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +
+              ' blocks to be displayed.');
+
+          // Give editing options so that the user can make an invalid shadow block
+          // a normal block.
+          document.getElementById('button_editShadow').disabled = false;
+        } else {
+
+          // No block selected that is a shadow block or could be a valid shadow block.
+          // Disable block editing.
+          document.getElementById('button_editShadow').disabled = true;
+          document.getElementById('dropdown_editShadowRemove').classList.remove("show");
+          document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+        }
       }
     }
   });

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -54,7 +54,7 @@ goog.require('goog.ui.ColorPicker');
 
     <div class='dropdown'>
     <button id="button_add">+</button>
-    <div id="dropdown_add" class="dropdown-content">
+    <div id="dropdownDiv_add" class="dropdown-content">
       <a id='dropdown_newCategory'>New Category</a>
       <a id='dropdown_loadCategory'>Standard Category</a>
       <a id='dropdown_separator'>Separator</a>
@@ -69,7 +69,7 @@ goog.require('goog.ui.ColorPicker');
     <p>&nbsp;</p>
     <div class='dropdown'>
     <button id="button_editCategory">Edit Category</button>
-    <div id="dropdown_editCategory" class="dropdown-content">
+    <div id="dropdownDiv_editCategory" class="dropdown-content">
       <a id='dropdown_name'>Name</a>
       <a id='dropdown_color'>Color</a>
     </div>
@@ -77,10 +77,10 @@ goog.require('goog.ui.ColorPicker');
 
     <div class='dropdown'>
     <button id="button_editShadow">Edit Block</button>
-    <div id="dropdown_editShadowAdd" class="dropdown-content">
+    <div id="dropdownDiv_editShadowAdd" class="dropdown-content">
       <a id='dropdown_addShadow'>Add Shadow</a>
     </div>
-    <div id="dropdown_editShadowRemove" class="dropdown-content">
+    <div id="dropdownDiv_editShadowRemove" class="dropdown-content">
       <a id='dropdown_removeShadow'>Remove Shadow</a>
     </div>
     </div>
@@ -489,19 +489,19 @@ goog.require('goog.ui.ColorPicker');
 
   // Wrappers to attach buttons to method calls for the controller object
   var addWrapper = function() {
-    document.getElementById('dropdown_add').classList.toggle("show");
+    document.getElementById('dropdownDiv_add').classList.toggle("show");
   };
   var newCategoryWrapper = function() {
     controller.addCategory();
-    document.getElementById('dropdown_add').classList.remove("show");
+    document.getElementById('dropdownDiv_add').classList.remove("show");
   };
   var loadCategoryWrapper = function() {
     controller.loadCategory();
-    document.getElementById('dropdown_add').classList.remove("show");
+    document.getElementById('dropdownDiv_add').classList.remove("show");
   };
   var separatorWrapper = function() {
     controller.addSeparator();
-    document.getElementById('dropdown_add').classList.remove("show");
+    document.getElementById('dropdownDiv_add').classList.remove("show");
   };
   var removeWrapper = function() {
     controller.removeElement();
@@ -519,19 +519,19 @@ goog.require('goog.ui.ColorPicker');
     controller.moveElement(1);
   };
   var editCategoryWrapper = function() {
-    document.getElementById('dropdown_editCategory').classList.toggle("show");
+    document.getElementById('dropdownDiv_editCategory').classList.toggle("show");
   };
   var nameWrapper = function() {
     controller.changeCategoryName();
-    document.getElementById('dropdown_editCategory').classList.remove("show");
+    document.getElementById('dropdownDiv_editCategory').classList.remove("show");
   };
   var shadowAddWrapper = function() {
     controller.addShadow();
-    document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+    document.getElementById('dropdownDiv_editShadowAdd').classList.remove("show");
   };
-    var shadowRemoveWrapper = function() {
+  var shadowRemoveWrapper = function() {
     controller.removeShadow();
-    document.getElementById('dropdown_editShadowRemove').classList.remove("show");
+    document.getElementById('dropdownDiv_editShadowRemove').classList.remove("show");
     // If turning invalid shadow block back to normal block, remove warning and disable
     // block editing privileges.
     Blockly.selected.setWarningText(null);
@@ -548,12 +548,12 @@ goog.require('goog.ui.ColorPicker');
         // has a surrounding parent), let the user make it a shadow block.
         // Use toggle instead of add so that the user can click the button again
         // to make the dropdown disappear without clicking one of the options.
-        document.getElementById('dropdown_editShadowRemove').classList.remove("show");
-        document.getElementById('dropdown_editShadowAdd').classList.toggle("show");
+        document.getElementById('dropdownDiv_editShadowRemove').classList.remove("show");
+        document.getElementById('dropdownDiv_editShadowAdd').classList.toggle("show");
       } else {
         // If the block is a shadow block, let the user make it a normal block.
-        document.getElementById('dropdown_editShadowAdd').classList.remove("show");
-        document.getElementById('dropdown_editShadowRemove').classList.toggle("show");
+        document.getElementById('dropdownDiv_editShadowAdd').classList.remove("show");
+        document.getElementById('dropdownDiv_editShadowRemove').classList.toggle("show");
       }
     }
   };
@@ -562,7 +562,7 @@ goog.require('goog.ui.ColorPicker');
   };
   var clearWrapper = function() {
     controller.clear();
-  }
+  };
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -592,10 +592,21 @@ goog.require('goog.ui.ColorPicker');
       ('change', importWrapper);
   document.getElementById('button_clear').addEventListener
       ('click', clearWrapper);
-  document.getElementById('dropdown_editShadowAdd').addEventListener
+  document.getElementById('dropdown_addShadow').addEventListener
       ('click', shadowAddWrapper);
-    document.getElementById('dropdown_editShadowRemove').addEventListener
+  document.getElementById('dropdown_removeShadow').addEventListener
       ('click', shadowRemoveWrapper);
+
+  // Use up and down arrow keys to move categories.
+  // TODO(evd2014): When merge with next CL for editing preloaded blocks, make sure
+  // mode is toolbox.
+  window.addEventListener('keydown', function(e) {
+    if (e.keyCode == 38) {    // Arrow up.
+      upWrapper();
+    } else if (e.keyCode == 40) {   // Arrow down.
+      downWrapper();
+    }
+  });
 
   // Create color picker with specific set of Blockly colors.
   var colorPicker = new goog.ui.ColorPicker();
@@ -607,7 +618,7 @@ goog.require('goog.ui.ColorPicker');
   popupPicker.setFocusable(true);
   goog.events.listen(popupPicker, 'change', function(e) {
         controller.changeSelectedCategoryColor(popupPicker.getSelectedColor());
-        document.getElementById('dropdown_editCategory').classList.remove
+        document.getElementById('dropdownDiv_editCategory').classList.remove
             ("show");
       });
 
@@ -655,8 +666,8 @@ goog.require('goog.ui.ColorPicker');
           // No block selected that is a shadow block or could be a valid shadow block.
           // Disable block editing.
           document.getElementById('button_editShadow').disabled = true;
-          document.getElementById('dropdown_editShadowRemove').classList.remove("show");
-          document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+          document.getElementById('dropdownDiv_editShadowRemove').classList.remove("show");
+          document.getElementById('dropdownDiv_editShadowAdd').classList.remove("show");
         }
       }
     }

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -311,7 +311,7 @@ FactoryController.prototype.reinjectPreview = function(tree) {
        length: 3,
        colour: '#ccc',
        snap: true},
-     media: '../../media/',
+     media: '../../../media/',
      toolbox: previewToolbox,
      zoom:
        {controls: true,

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -643,6 +643,18 @@ FactoryController.prototype.removeShadow = function() {
 };
 
 /**
+ * Given a unique block ID, uses the model to determine if a block is a
+ * user-generated shadow block.
+ *
+ * @param {!string} blockId The unique ID of the block to examine.
+ * @return {boolean} True if the block is a user-generated shadow block, false
+ *    otherwise.
+ */
+FactoryController.prototype.isUserGenShadowBlock = function(blockId) {
+  return this.model.isShadowBlock(blockId);
+}
+
+/**
  * Call when importing XML containing real shadow blocks. This function turns
  * all real shadow blocks loaded in the workspace into user-generated shadow
  * blocks, meaning they are marked as shadow blocks by the model and appear as

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -290,6 +290,8 @@ FactoryModel.prototype.removeShadowBlock = function(blockId) {
  * Determines if a block is a shadow block given a unique block ID.
  *
  * @param {!string} blockId The unique ID of the block to examine.
+ * @return {boolean} True if the block is a user-generated shadow block, false
+ *    otherwise.
  */
 FactoryModel.prototype.isShadowBlock = function(blockId) {
   for (var i = 0; i < this.shadowBlocks.length; i++) {


### PR DESCRIPTION
1.) Fixed small bug in selecting block to get editing options. Now don't have to deselect and reselect to get editing button enabled.

2.) Display a warning message on a block if the user disconnects a user-generated shadow block from its parent (making it no longer a valid shadow block). Enable the editing option for removing the shadow to give the user an easy way to fix the problem. 

![shadow warning](https://cloud.githubusercontent.com/assets/18580768/17418650/7155fdfa-5a4e-11e6-81d2-4942059ece44.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/35)

<!-- Reviewable:end -->
