### PR TITLE
Workspace Factory #13: Pre-loaded Blocks in Workspace

### DIFF
--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -50,7 +50,7 @@ goog.require('goog.ui.ColorPicker');
         </div>
 
         <button id="button_print">Print Toolbox</button>
-        <button id="button_clear">Clear</button>
+        <button id="button_clear">Clear Toolbox</button>
       </p>
     </td>
   </tr>
@@ -586,7 +586,7 @@ goog.require('goog.ui.ColorPicker');
     document.getElementById('dropdownDiv_export').classList.remove("show");
   };
   var clearWrapper = function() {
-    controller.clear();
+    controller.clearToolbox();
   };
   var editToolboxWrapper = function() {
     controller.setMode(FactoryController.MODE_TOOLBOX);

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -531,7 +531,7 @@ goog.require('goog.ui.ColorPicker');
   };
   var exportWrapper = function() {
     document.getElementById('dropdownDiv_export').classList.toggle("show");
-    //controller.exportConfig();
+    document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var printWrapper = function() {
     controller.printConfig();
@@ -581,9 +581,9 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
-  var importWrapper = function() {  // took an event e before, need to have listener with 'change' for files
+  var importWrapper = function() {
     document.getElementById('dropdownDiv_import').classList.toggle("show");
-    //controller.importFile(event.target.files[0]);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
   };
   var clearWrapper = function() {
     controller.clear();
@@ -595,13 +595,26 @@ goog.require('goog.ui.ColorPicker');
     controller.setMode(FactoryController.MODE_PRELOAD);
   };
   var importToolboxWrapper = function(e) {
-    controller.importFile(event.target.files[0], true);
+    controller.importFile(event.target.files[0], FactoryController.MODE_TOOLBOX);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var importPreloadWrapper = function(e) {
-    controller.importFile(event.target.files[0]), false;
+    controller.importFile(event.target.files[0], FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
+  var exportToolboxWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportPreloadWrapper = function() {
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportAllWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -613,6 +626,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', separatorWrapper);
   document.getElementById('button_remove').addEventListener
       ('click', removeWrapper);
+  document.getElementById('dropdown_exportToolbox').addEventListener
+      ('click', exportToolboxWrapper);
+  document.getElementById('dropdown_exportPreload').addEventListener
+      ('click', exportPreloadWrapper);
+  document.getElementById('dropdown_exportAll').addEventListener
+      ('click', exportAllWrapper);
   document.getElementById('button_export').addEventListener
       ('click', exportWrapper);
   document.getElementById('button_print').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -656,7 +656,7 @@ goog.require('goog.ui.ColorPicker');
       ('click', clearWrapper);
   document.getElementById('dropdown_addShadow').addEventListener
       ('click', shadowAddWrapper);
-  document.getElementById('dropdown_editShadowRemove').addEventListener
+  document.getElementById('dropdown_removeShadow').addEventListener
       ('click', shadowRemoveWrapper);
   document.getElementById('tab_toolbox').addEventListener
       ('click', editToolboxWrapper);

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -701,6 +701,7 @@ goog.require('goog.ui.ColorPicker');
     // blocks when dragging them into workspace. Could cause problems if ever load
     // blocks into workspace directly without calling updatePreview.
     if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
+      controller.saveStateFromWorkspace();
       controller.updatePreview();
     }
 

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -30,10 +30,26 @@ goog.require('goog.ui.ColorPicker');
   <tr>
     <td>
       <p>
-        <input type="file" id="input_import" class="inputfile"></input>
-        <label for="input_import">Import</label>
+        <div class="dropdown">
+        <button id="button_import">Import</button>
+        <div id="dropdownDiv_import" class="dropdown-content">
+          <input type="file" id="input_importToolbox" class="inputfile"></input>
+          <label for="input_importToolbox">Toolbox</label>
+          <input type="file" id="input_importPreload" class="inputfile"></input>
+          <label for="input_importPreload">Workspace Blocks</label>
+        </div>
+        </div>
+
+        <div class="dropdown">
         <button id="button_export">Export</button>
-        <button id="button_print">Print</button>
+        <div id="dropdownDiv_export" class="dropdown-content">
+          <a id='dropdown_exportToolbox'>Toolbox</a>
+          <a id='dropdown_exportPreload'>Workspace Blocks</a>
+          <a id='dropdown_exportAll'>All</a>
+        </div>
+        </div>
+
+        <button id="button_print">Print Toolbox</button>
         <button id="button_clear">Clear</button>
       </p>
     </td>
@@ -514,7 +530,8 @@ goog.require('goog.ui.ColorPicker');
     controller.removeElement();
   };
   var exportWrapper = function() {
-    controller.exportConfig();
+    document.getElementById('dropdownDiv_export').classList.toggle("show");
+    //controller.exportConfig();
   };
   var printWrapper = function() {
     controller.printConfig();
@@ -564,18 +581,27 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
-  var importWrapper = function(event) {
-    controller.importFile(event.target.files[0]);
+  var importWrapper = function() {  // took an event e before, need to have listener with 'change' for files
+    document.getElementById('dropdownDiv_import').classList.toggle("show");
+    //controller.importFile(event.target.files[0]);
   };
   var clearWrapper = function() {
     controller.clear();
   };
   var editToolboxWrapper = function() {
     controller.setMode(FactoryController.MODE_TOOLBOX);
-  }
+  };
   var editPreloadWrapper = function() {
     controller.setMode(FactoryController.MODE_PRELOAD);
-  }
+  };
+  var importToolboxWrapper = function(e) {
+    controller.importFile(event.target.files[0], true);
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
+  var importPreloadWrapper = function(e) {
+    controller.importFile(event.target.files[0]), false;
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -601,8 +627,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', editShadowWrapper);
   document.getElementById('dropdown_name').addEventListener
       ('click', nameWrapper);
-  document.getElementById('input_import').addEventListener
-      ('change', importWrapper);
+  document.getElementById('button_import').addEventListener
+      ('click', importWrapper);
+  document.getElementById('input_importToolbox').addEventListener
+      ('change', importToolboxWrapper);
+  document.getElementById('input_importPreload').addEventListener
+      ('change', importPreloadWrapper);
   document.getElementById('button_clear').addEventListener
       ('click', clearWrapper);
   document.getElementById('dropdown_addShadow').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -42,11 +42,15 @@ goog.require('goog.ui.ColorPicker');
 
 <section id="createDiv">
   <p>Drag blocks into your toolbox:</p>
+  <table id='workspaceTabs'>
+    <td id="tab_toolbox" class="tabon">Toolbox</td>
+    <td id="tab_preload" class="taboff">Pre-loaded Workspace</td>
+  </table>
   <section id="toolbox_section">
     <div id="toolbox_blocks" class="content"></div>
     <div id='disable_div'></div>
   </section>
-  <aside id="category_section">
+  <aside id="toolbox_div">
     <table id="categoryTable">
       <td id="tab_help">Your categories will appear here</td>
     </table>
@@ -75,7 +79,11 @@ goog.require('goog.ui.ColorPicker');
     </div>
     </div>
 
-    <div class='dropdown'>
+  </aside>
+  <aside id='preload_div' style='display:none'>
+  </aside>
+
+  <div class='dropdown'>
     <button id="button_editShadow">Edit Block</button>
     <div id="dropdownDiv_editShadowAdd" class="dropdown-content">
       <a id='dropdown_addShadow'>Add Shadow</a>
@@ -83,9 +91,8 @@ goog.require('goog.ui.ColorPicker');
     <div id="dropdownDiv_editShadowRemove" class="dropdown-content">
       <a id='dropdown_removeShadow'>Remove Shadow</a>
     </div>
-    </div>
+  </div>
 
-  </aside>
 </section>
 
 <aside id="previewDiv">
@@ -563,6 +570,12 @@ goog.require('goog.ui.ColorPicker');
   var clearWrapper = function() {
     controller.clear();
   };
+  var editToolboxWrapper = function() {
+    controller.setTab(FactoryController.TAB_TOOLBOX);
+  }
+  var editPreloadWrapper = function() {
+    controller.setTab(FactoryController.TAB_PRELOAD);
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -594,8 +607,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', clearWrapper);
   document.getElementById('dropdown_addShadow').addEventListener
       ('click', shadowAddWrapper);
-  document.getElementById('dropdown_removeShadow').addEventListener
+  document.getElementById('dropdown_editShadowRemove').addEventListener
       ('click', shadowRemoveWrapper);
+  document.getElementById('tab_toolbox').addEventListener
+      ('click', editToolboxWrapper);
+  document.getElementById('tab_preload').addEventListener
+      ('click', editPreloadWrapper);
 
   // Use up and down arrow keys to move categories.
   // TODO(evd2014): When merge with next CL for editing preloaded blocks, make sure

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -41,7 +41,7 @@ goog.require('goog.ui.ColorPicker');
 </table>
 
 <section id="createDiv">
-  <p>Drag blocks into your toolbox:</p>
+  <p id="editHelpText">Drag blocks into your toolbox:</p>
   <table id='workspaceTabs'>
     <td id="tab_toolbox" class="tabon">Toolbox</td>
     <td id="tab_preload" class="taboff">Pre-loaded Workspace</td>
@@ -571,10 +571,10 @@ goog.require('goog.ui.ColorPicker');
     controller.clear();
   };
   var editToolboxWrapper = function() {
-    controller.setTab(FactoryController.TAB_TOOLBOX);
+    controller.setMode(FactoryController.MODE_TOOLBOX);
   }
   var editPreloadWrapper = function() {
-    controller.setTab(FactoryController.TAB_PRELOAD);
+    controller.setMode(FactoryController.MODE_PRELOAD);
   }
 
   document.getElementById('button_add').addEventListener

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -21,6 +21,10 @@ aside {
   border-bottom: none;
 }
 
+#workspaceTabs>table {
+  float: right;
+}
+
 td.tabon {
   border-bottom-color: #ddd !important;
   background-color: #ddd;
@@ -135,7 +139,7 @@ td {
   width: 30%;
 }
 
-#category_section {
+#toolbox_div {
   width: 20%;
 }
 

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -63,33 +63,6 @@ button:hover:not(:disabled)>* {
   opacity: 1;
 }
 
-label {
-  border-radius: 4px;
-  border: 1px solid #ddd;
-  background-color: #eee;
-  color: #000;
-  font-size: large;
-  margin: 0 5px;
-  padding: 10px;
-}
-
-label:hover:not(:disabled) {
-  box-shadow: 2px 2px 5px #888;
-}
-
-label:disabled {
-  opacity: .6;
-}
-
-label>* {
-  opacity: .6;
-  vertical-align: text-bottom;
-}
-
-label:hover:not(:disabled)>* {
-  opacity: 1;
-}
-
 table {
   border: none;
   border-collapse: collapse;
@@ -217,8 +190,19 @@ td {
     text-decoration: none;
 }
 
+.dropdown-content label {
+    color: black;
+    display: block;
+    padding: 12px 16px;
+    text-decoration: none;
+}
+
 /* Change color of dropdown links on hover */
 .dropdown-content a:hover {
+  background-color: #f1f1f1
+}
+
+.dropdown-content label:hover {
   background-color: #f1f1f1
 }
 

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -21,10 +21,6 @@ aside {
   border-bottom: none;
 }
 
-#workspaceTabs>table {
-  float: right;
-}
-
 td.tabon {
   border-bottom-color: #ddd !important;
   background-color: #ddd;

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -173,28 +173,28 @@ td {
 
 /* Dropdown Content (Hidden by Default) */
 .dropdown-content {
-    background-color: #f9f9f9;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,.2);
-    display: none;
-    min-width: 170px;
-    opacity: 1;
-    position: absolute;
-    z-index: 1;
+  background-color: #f9f9f9;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,.2);
+  display: none;
+  min-width: 170px;
+  opacity: 1;
+  position: absolute;
+  z-index: 1;
 }
 
 /* Links inside the dropdown */
 .dropdown-content a {
-    color: black;
-    display: block;
-    padding: 12px 16px;
-    text-decoration: none;
+  color: black;
+  display: block;
+  padding: 12px 16px;
+  text-decoration: none;
 }
 
 .dropdown-content label {
-    color: black;
-    display: block;
-    padding: 12px 16px;
-    text-decoration: none;
+  color: black;
+  display: block;
+  padding: 12px 16px;
+  text-decoration: none;
 }
 
 /* Change color of dropdown links on hover */

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -253,15 +253,42 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
 };
 
 /**
- * Tied to "Export Config" button. Gets a file name from the user and downloads
+ * Tied to "Export" button. Gets a file name from the user and downloads
  * the corresponding configuration xml to that file.
+ *
+ * @param {!string} exportMode The type of file to export
+ *    (FactoryController.MODE_TOOLBOX for the toolbox configuration, and
+ *    FactoryController.MODE_PRELOAD for the pre-loaded workspace configuration)
  */
-FactoryController.prototype.exportConfig = function() {
+FactoryController.prototype.exportFile = function(exportMode) {
   // Generate XML.
-  var configXml = Blockly.Xml.domToPrettyText
-      (this.generator.generateConfigXml(this.toolboxWorkspace));
+  if (exportMode == FactoryController.MODE_TOOLBOX) {
+    // Export the toolbox XML.
+    if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
+      // Capture any changes made by user before generating XML if in
+      // toolbox mode.
+      this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+    }
+    var configXml = Blockly.Xml.domToPrettyText
+        (this.generator.generateToolboxXml());
+  } else if (exportMode == FactoryController.MODE_PRELOAD) {
+    // Export the pre-loaded block XML.
+    if (this.selectedMode == FactoryController.MODE_PRELOAD) {
+      // Capture any changes made by user before generating XML if in
+      // preload workspace mode.
+      this.model.savePreloadXml(Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+    }
+    var configXml = Blockly.Xml.domToPrettyText
+        (this.generator.generateWorkspaceXml());
+  } else {
+    // Unknown mode. Throw error.
+    throw new Error ("Unknown export mode: " + exportMode);
+  }
+
   // Get file name.
-  var fileName = prompt("File Name: ");
+  var fileName = prompt('File Name for ' + (exportMode ==
+      FactoryController.MODE_TOOLBOX ? 'toolbox XML: ' :
+      'pre-loaded workspace XML: '));
   if (!fileName) { // If cancelled
     return;
   }
@@ -271,12 +298,15 @@ FactoryController.prototype.exportConfig = function() {
  };
 
 /**
- * Tied to "Print Config" button. Mainly used for debugging purposes. Prints
+ * Tied to "Print" button. Mainly used for debugging purposes. Prints
  * the configuration XML to the console.
  */
 FactoryController.prototype.printConfig = function() {
+  // Capture any changes made by user before generating XML.
+  this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+  // Print XML.
   window.console.log(Blockly.Xml.domToPrettyText
-      (this.generator.generateConfigXml(this.toolboxWorkspace)));
+      (this.generator.generateToolboxXml()));
 };
 
 /**
@@ -294,9 +324,12 @@ FactoryController.prototype.updatePreview = function() {
 
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
+    // Capture any changes made by user before generating XML.
+    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+    // Get toolbox XML.
     var tree = Blockly.Options.parseToolboxTree
-        (this.generator.generateConfigXml(this.toolboxWorkspace));
-
+        (this.generator.generateToolboxXml());
+    // No categories, creates a simple flyout.
     if (tree.getElementsByTagName('category').length == 0) {
       // No categories, creates a simple flyout.
       if (this.previewWorkspace.toolbox_) {
@@ -318,13 +351,14 @@ FactoryController.prototype.updatePreview = function() {
     // blocks don't get cleared when updating preview from event listeners while
     // switching modes.
     this.previewWorkspace.clear();
-    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
-        (this.model.getPreloadXml()), this.previewWorkspace);
+    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
+        this.previewWorkspace);
   } else {
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
-    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
-        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)),
+    this.model.savePreloadXml
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
   }
 
@@ -544,16 +578,20 @@ FactoryController.prototype.addSeparator = function() {
 
 /**
  * Connected to the import button. Given the file path inputted by the user
- * from file input, this function loads that toolbox XML to the workspace,
- * creating category and separator tabs as necessary. This allows the user
- * to be able to edit toolboxes given their XML form. Catches errors from
+ * from file input, if the import mode is for the toolbox, this function loads
+ * that toolbox XML to the workspace, creating category and separator tabs as
+ * necessary. If the import mode is for pre-loaded blocks in the workspace,
+ * this function loads that XML to the workspace to be edited further. This
+ * function switches mode to whatever the import mode is. Catches errors from
  * file reading and prints an error message alerting the user.
  *
  * @param {string} file The path for the file to be imported into the workspace.
  * Should contain valid toolbox XML.
+ * @param {!string} importMode The mode corresponding to the type of file the
+ *    user is importing (FactoryController.MODE_TOOLBOX or
+ *    FactoryController.MODE_PRELOAD).
  */
- // UPDATE COMMENTS
-FactoryController.prototype.importFile = function(file, isToolbox) {
+FactoryController.prototype.importFile = function(file, importMode) {
   // Exit if cancelled.
   if (!file) {
     return;
@@ -566,12 +604,17 @@ FactoryController.prototype.importFile = function(file, isToolbox) {
     // Print error message if fail.
     try {
       var tree = Blockly.Xml.textToDom(reader.result);
-      if (isToolbox) {
+      if (importMode == FactoryController.MODE_TOOLBOX) {
+        // Switch mode and import toolbox XML.
         controller.setMode(FactoryController.MODE_TOOLBOX);
         controller.importToolboxFromTree_(tree);
-      } else {
+      } else if (importMode == FactoryController.MODE_PRELOAD) {
+        // Switch mode and import pre-loaded workspace XML.
         controller.setMode(FactoryController.MODE_PRELOAD);
         controller.importPreloadFromTree_(tree);
+      } else {
+        // Throw error if invalid mode.
+        throw new Error("Unknown import mode: " + importMode);
       }
     } catch(e) {
       alert('Cannot load XML from file.');
@@ -579,14 +622,14 @@ FactoryController.prototype.importFile = function(file, isToolbox) {
     }
   }
 
-  // Read the file.
+  // Read the file asynchronously.
   reader.readAsText(file);
 };
 
 /**
  * Given a XML DOM tree, loads it into the toolbox editing area so that the
  * user can continue editing their work. Assumes that tree is in valid toolbox
- * XML format.
+ * XML format. Assumes that the mode is MODE_TOOLBOX.
  * @private
  *
  * @param {!Element} tree XML tree to be loaded to toolbox editing area.
@@ -651,12 +694,18 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
   this.updatePreview();
 };
 
+/**
+ * Given a XML DOM tree, loads it into the pre-loaded workspace editing area.
+ * Assumes that tree is in valid XML format and that the selected mode is
+ * MODE_PRELOAD.
+ *
+ * @param {!Element} tree XML tree to be loaded to pre-loaded block editing
+ *    area.
+ */
 FactoryController.prototype.importPreloadFromTree_ = function(tree) {
   this.clearAndLoadXml_(tree);
   this.model.savePreloadXml(tree);
-  this.updatePreview(); //assuming that updatePreview still calls domToWorkspace regardless of mode
-  // this.previewWorkspace.domToWorkspace
-  //     (this.generator.generateWorkspaceXml(tree));
+  this.updatePreview();
 }
 
 /**
@@ -761,8 +810,10 @@ FactoryController.prototype.setMode = function(mode) {
 
   if (mode == FactoryController.MODE_TOOLBOX) {
     // Open the toolbox editing space.
-    this.model.savePreloadXml(this.generator.generateWorkspaceXml
-        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)));
+    document.getElementById('editHelpText').textContent =
+        'Drag blocks into your toolbox:';
+    this.model.savePreloadXml
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
     this.clearAndLoadXml_(this.model.getSelectedXml());
     this.view.disableWorkspace(this.view.shouldDisableWorkspace
         (this.model.getSelected()));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -57,6 +57,13 @@ FactoryController = function(toolboxWorkspace, previewWorkspace) {
   this.selectedMode = FactoryController.MODE_TOOLBOX;
 };
 
+// Toolbox editing mode. Changes the user makes to the workspace updates the
+// toolbox.
+FactoryController.MODE_TOOLBOX = 'toolbox';
+// Pre-loaded workspace editing mode. Changes the user makes to the workspace
+// udpates the pre-loaded blocks.
+FactoryController.MODE_PRELOAD = 'preload';
+
 /**
  * Currently prompts the user for a name, checking that it's valid (not used
  * before), and then creates a tab and switches to it.
@@ -725,10 +732,11 @@ FactoryController.prototype.setMode = function(mode) {
   // Update selected tab.
   this.selectedMode = mode;
 
+  // Update help text above workspace.
+  this.view.updateHelpText(mode);
+
   if (mode == FactoryController.MODE_TOOLBOX) {
     // Open the toolbox editing space.
-    document.getElementById('editHelpText').textContent =
-        'Drag blocks into your toolbox:';
     this.model.savePreloadXml(this.generator.generateWorkspaceXml
         (this.toolboxWorkspace));
     this.clearAndLoadXml_(this.model.getSelectedXml());
@@ -736,8 +744,6 @@ FactoryController.prototype.setMode = function(mode) {
         (this.model.getSelected()));
   } else {
     // Open the pre-loaded workspace editing space.
-    document.getElementById('editHelpText').textContent =
-        'Drag blocks into your pre-loaded workspace:';
     if (this.model.getSelected()) {
       this.model.getSelected().saveFromWorkspace(this.toolboxWorkspace);
     }
@@ -760,10 +766,3 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
   this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
       (this.toolboxWorkspace.getAllBlocks()));
 }
-
-// Toolbox editing mode. Changes the user makes to the workspace updates the
-// toolbox.
-FactoryController.MODE_TOOLBOX = 'toolbox';
-// Pre-loaded workspace editing mode. Changes the user makes to the workspace
-// udpates the pre-loaded blocks.
-FactoryController.MODE_PRELOAD = 'preload';

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -369,7 +369,7 @@ FactoryController.prototype.updatePreview = function() {
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
-  } else {
+  } else if (this.selectedMode == FactoryController.MODE_PRELOAD){
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
@@ -426,9 +426,8 @@ FactoryController.prototype.reinjectPreview = function(tree) {
  * currently in use, exits if user presses cancel.
  */
 FactoryController.prototype.changeCategoryName = function() {
-  // Return if no category selected or element a separator.
-  if (!this.model.getSelected() ||
-      this.model.getSelected().type == ListElement.TYPE_SEPARATOR) {
+  // Return if a category is not selected.
+  if (this.model.getSelected().type != ListElement.TYPE_CATEGORY) {
     return;
   }
   // Get new name from user.
@@ -496,9 +495,8 @@ FactoryController.prototype.moveElementToIndex = function(element, newIndex,
  * a valid CSS string.
  */
 FactoryController.prototype.changeSelectedCategoryColor = function(color) {
-  // Return if no category selected or element a separator.
-  if (!this.model.getSelected() ||
-      this.model.getSelected().type == ListElement.TYPE_SEPARATOR) {
+  // Return if category is not selected.
+  if (this.model.getSelected().type != ListElement.TYPE_CATEGORY) {
     return;
   }
   // Change color of selected category.

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -276,24 +276,15 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
  *    FactoryController.MODE_PRELOAD for the pre-loaded workspace configuration)
  */
 FactoryController.prototype.exportFile = function(exportMode) {
+  // Save workspace in current state.
+  this.saveStateFromWorkspace();
   // Generate XML.
   if (exportMode == FactoryController.MODE_TOOLBOX) {
     // Export the toolbox XML.
-    if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
-      // Capture any changes made by user before generating XML if in
-      // toolbox mode.
-      this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
-    }
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateToolboxXml());
   } else if (exportMode == FactoryController.MODE_PRELOAD) {
     // Export the pre-loaded block XML.
-    if (this.selectedMode == FactoryController.MODE_PRELOAD) {
-      // Capture any changes made by user before generating XML if in
-      // preload workspace mode.
-      this.model.savePreloadXml(Blockly.Xml.workspaceToDom
-          (this.toolboxWorkspace));
-    }
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateWorkspaceXml());
   } else {
@@ -319,7 +310,7 @@ FactoryController.prototype.exportFile = function(exportMode) {
  */
 FactoryController.prototype.printConfig = function() {
   // Capture any changes made by user before generating XML.
-  this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+  this.saveStateFromWorkspace();
   // Print XML.
   window.console.log(Blockly.Xml.domToPrettyText
       (this.generator.generateToolboxXml()));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -291,19 +291,22 @@ FactoryController.prototype.updatePreview = function() {
   // Disable events to stop updatePreview from recursively calling itself
   // through event handlers.
   Blockly.Events.disable();
+
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
     var tree = Blockly.Options.parseToolboxTree
         (this.generator.generateConfigXml(this.toolboxWorkspace));
-    // No categories, creates a simple flyout.
+
     if (tree.getElementsByTagName('category').length == 0) {
+      // No categories, creates a simple flyout.
       if (this.previewWorkspace.toolbox_) {
         this.reinjectPreview(tree); // Switch to simple flyout, more expensive.
       } else {
         this.previewWorkspace.flyout_.show(tree.childNodes);
       }
-    // Uses categories, creates a toolbox.
+
     } else {
+      // Uses categories, creates a toolbox.
       if (!previewWorkspace.toolbox_) {
         this.reinjectPreview(tree); // Create a toolbox, more expensive.
       } else {
@@ -323,6 +326,7 @@ FactoryController.prototype.updatePreview = function() {
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
         (this.toolboxWorkspace), this.previewWorkspace);
   }
+
   // Reenable events.
   Blockly.Events.enable();
 };
@@ -725,7 +729,6 @@ FactoryController.prototype.convertShadowBlocks = function() {
  *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
  */
 FactoryController.prototype.setMode = function(mode) {
-
   // Set tab selection and display appropriate tab.
   this.view.setModeSelection(mode);
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -379,7 +379,7 @@ FactoryController.prototype.saveStateFromWorkspace = function() {
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
     this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
-  } else {
+  } else if (this.selectedMode == FactoryController.MODE_PRELOAD) {
     // If currently editing the pre-loaded workspace.
     this.model.savePreloadXml
         (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -151,30 +151,41 @@ FactoryController.prototype.removeElement = function() {
   if (!this.model.getSelected()) {
     return;
   }
+
   // Check if user wants to remove current category.
   var check = confirm('Are you sure you want to delete the currently selected '
         + this.model.getSelected().type + '?');
   if (!check) { // If cancelled, exit.
     return;
   }
+
   var selectedId = this.model.getSelectedId();
   var selectedIndex = this.model.getIndexByElementId(selectedId);
   // Delete element visually.
   this.view.deleteElementRow(selectedId, selectedIndex);
   // Delete element in model.
   this.model.deleteElementFromList(selectedIndex);
+
   // Find next logical element to switch to.
   var next = this.model.getElementByIndex(selectedIndex);
   if (!next && this.model.hasToolbox()) {
     next = this.model.getElementByIndex(selectedIndex - 1);
   }
   var nextId = next ? next.id : null;
+
   // Open next element.
   this.clearAndLoadElement(nextId);
+
+  // If no element to switch to, display message, clear the workspace, and
+  // set a default selected element not in toolbox list in the model.
   if (!nextId) {
     alert('You currently have no categories or separators. All your blocks' +
         ' will be displayed in a single flyout.');
+    this.toolboxWorkspace.clear();
+    this.toolboxWorkspace.clearUndo();
+    this.model.setDefaultSelected();
   }
+
   // Update preview.
   this.updatePreview();
 };
@@ -235,17 +246,21 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
     this.view.disableWorkspace(false);
   }
 
-  // Set next category.
-  this.model.setSelectedById(id);
+  // If switching to another category, set category selection in the model and
+  // view.
+  if (id != null) {
+    // Set next category.
+    this.model.setSelectedById(id);
 
-  // Clears workspace and loads next category.
-  this.clearAndLoadXml_(this.model.getSelectedXml());
+    // Clears workspace and loads next category.
+    this.clearAndLoadXml_(this.model.getSelectedXml());
 
-  // Selects the next tab.
-  this.view.setCategoryTabSelection(id, true);
+    // Selects the next tab.
+    this.view.setCategoryTabSelection(id, true);
 
-  // Order blocks as if shown in the flyout.
-  this.toolboxWorkspace.cleanUp_();
+    // Order blocks as if shown in the flyout.
+    this.toolboxWorkspace.cleanUp_();
+  }
 
   // Update category editing buttons.
   this.view.updateState(this.model.getIndexByElementId
@@ -710,9 +725,10 @@ FactoryController.prototype.importPreloadFromTree_ = function(tree) {
 
 /**
  * Clears the toolbox editing area completely, deleting all categories and all
- * blocks in the model and view.
+ * blocks in the model and view. Sets the mode to toolbox mode.
  */
-FactoryController.prototype.clear = function() {
+FactoryController.prototype.clearToolbox = function() {
+  this.setMode(FactoryController.MODE_TOOLBOX);
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
   this.view.addEmptyCategoryMessage();

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -278,6 +278,7 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
 FactoryController.prototype.exportFile = function(exportMode) {
   // Save workspace in current state.
   this.saveStateFromWorkspace();
+
   // Generate XML.
   if (exportMode == FactoryController.MODE_TOOLBOX) {
     // Export the toolbox XML.

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -303,6 +303,13 @@ FactoryController.prototype.updatePreview = function() {
         this.previewWorkspace.toolbox_.populate_(tree);
       }
     }
+
+    // Update pre-loaded blocks in the preview workspace to make sure that
+    // blocks don't get cleared when updating preview from event listeners while
+    // switching modes.
+    this.previewWorkspace.clear();
+    Blockly.Xml.domToWorkspace(this.model.getPreloadXml(),
+        this.previewWorkspace);
   } else {
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -70,10 +70,10 @@ FactoryController.MODE_PRELOAD = 'preload';
  */
 FactoryController.prototype.addCategory = function() {
   // Check if it's the first category added.
-  var firstCategory = !this.model.hasToolbox();
+  var isFirstCategory = !this.model.hasElements();
   // Give the option to save blocks if their workspace is not empty and they
   // are creating their first category.
-  if (firstCategory && this.toolboxWorkspace.getAllBlocks().length > 0) {
+  if (isFirstCategory && this.toolboxWorkspace.getAllBlocks().length > 0) {
     var confirmCreate = confirm('Do you want to save your work in another '
         + 'category? If you don\'t, the blocks in your workspace will be ' +
         'deleted.');
@@ -89,14 +89,14 @@ FactoryController.prototype.addCategory = function() {
     }
   }
   // After possibly creating a category, check again if it's the first category.
-  firstCategory = !this.model.hasToolbox();
+  isFirstCategory = !this.model.hasElements();
   // Get name from user.
   name = this.promptForNewCategoryName('Enter the name of your new category: ');
   if (!name) {  //Exit if cancelled.
     return;
   }
   // Create category.
-  this.createCategory(name, firstCategory);
+  this.createCategory(name, isFirstCategory);
   // Switch to category.
   this.switchElement(this.model.getCategoryIdByName(name));
   // Update preview.
@@ -110,15 +110,15 @@ FactoryController.prototype.addCategory = function() {
  *
  * @param {!string} name Name of category being added.
  * @param {!string} id The ID of the category being added.
- * @param {boolean} firstCategory True if it's the first category created,
+ * @param {boolean} isFirstCategory True if it's the first category created,
  * false otherwise.
  */
-FactoryController.prototype.createCategory = function(name, firstCategory) {
+FactoryController.prototype.createCategory = function(name, isFirstCategory) {
   // Create empty category
   var category = new ListElement(ListElement.TYPE_CATEGORY, name);
   this.model.addElementToList(category);
   // Create new category.
-  var tab = this.view.addCategoryRow(name, category.id, firstCategory);
+  var tab = this.view.addCategoryRow(name, category.id, isFirstCategory);
   this.addClickToSwitch(tab, category.id);
 };
 
@@ -168,7 +168,7 @@ FactoryController.prototype.removeElement = function() {
 
   // Find next logical element to switch to.
   var next = this.model.getElementByIndex(selectedIndex);
-  if (!next && this.model.hasToolbox()) {
+  if (!next && this.model.hasElements()) {
     next = this.model.getElementByIndex(selectedIndex - 1);
   }
   var nextId = next ? next.id : null;
@@ -183,7 +183,7 @@ FactoryController.prototype.removeElement = function() {
         ' will be displayed in a single flyout.');
     this.toolboxWorkspace.clear();
     this.toolboxWorkspace.clearUndo();
-    this.model.setDefaultSelected();
+    this.model.createDefaultSelectedIfEmpty();
   }
 
   // Update preview.
@@ -331,7 +331,9 @@ FactoryController.prototype.printConfig = function() {
  * Blockly with reinjectPreview, otherwise just updates without reinjecting.
  * Called whenever a list element is created, removed, or modified and when
  * Blockly move and delete events are fired. Do not call on create events
- * or disabling will cause the user to "drop" their current blocks.
+ * or disabling will cause the user to "drop" their current blocks. Make sure
+ * that no changes have been made to the workspace since updating the model
+ * (if this might be the case, call saveStateFromWorkspace).
  */
 FactoryController.prototype.updatePreview = function() {
   // Disable events to stop updatePreview from recursively calling itself
@@ -340,8 +342,6 @@ FactoryController.prototype.updatePreview = function() {
 
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
-    // Capture any changes made by user before generating XML.
-    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
     // Get toolbox XML.
     var tree = Blockly.Options.parseToolboxTree
         (this.generator.generateToolboxXml());
@@ -372,14 +372,27 @@ FactoryController.prototype.updatePreview = function() {
   } else {
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
-    this.model.savePreloadXml
-        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
   }
 
   // Reenable events.
   Blockly.Events.enable();
+};
+
+/**
+ * Saves the state from the workspace depending on the current mode. Should
+ * be called after making changes to the workspace.
+ */
+FactoryController.prototype.saveStateFromWorkspace = function() {
+  if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
+    // If currently editing the toolbox.
+    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+  } else {
+    // If currently editing the pre-loaded workspace.
+    this.model.savePreloadXml
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+  }
 };
 
 /**
@@ -529,7 +542,7 @@ FactoryController.prototype.loadCategory = function() {
     return;
   }
 
-  var firstCategory = !this.model.hasToolbox();
+  var isFirstCategory = !this.model.hasElements();
   // Copy the standard category in the model.
   var copy = standardCategory.copy();
 
@@ -537,8 +550,7 @@ FactoryController.prototype.loadCategory = function() {
   this.model.addElementToList(copy);
 
   // Update the copy in the view.
-  var tab = this.view.addCategoryRow(copy.name, copy.id, firstCategory);
-
+  var tab = this.view.addCategoryRow(copy.name, copy.id, isFirstCategory);
   this.addClickToSwitch(tab, copy.id);
   // Color the category tab in the view.
   if (copy.color) {
@@ -547,7 +559,9 @@ FactoryController.prototype.loadCategory = function() {
   // Switch to loaded category.
   this.switchElement(copy.id);
   // Convert actual shadow blocks to user-generated shadow blocks.
-  this.convertShadowBlocks();
+  this.convertShadowBlocks_();
+  // Save state from workspace before updating preview.
+  this.saveStateFromWorkspace();
   // Update preview.
   this.updatePreview();
 };
@@ -576,7 +590,7 @@ FactoryController.prototype.isStandardCategoryName = function(name) {
  */
 FactoryController.prototype.addSeparator = function() {
   // Don't allow the user to add a separator if a category has not been created.
-  if (!this.model.hasToolbox()) {
+  if (!this.model.hasElements()) {
     alert('Add a category before adding a separator.');
     return;
   }
@@ -706,6 +720,9 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
   }
   this.view.updateState(this.model.getIndexByElementId
       (this.model.getSelectedId()), this.model.getSelected());
+
+  this.saveStateFromWorkspace();
+
   this.updatePreview();
 };
 
@@ -720,6 +737,7 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
 FactoryController.prototype.importPreloadFromTree_ = function(tree) {
   this.clearAndLoadXml_(tree);
   this.model.savePreloadXml(tree);
+  this.saveStateFromWorkspace();
   this.updatePreview();
 }
 
@@ -735,6 +753,7 @@ FactoryController.prototype.clearToolbox = function() {
   this.view.updateState(-1, null);
   this.toolboxWorkspace.clear();
   this.toolboxWorkspace.clearUndo();
+  this.saveStateFromWorkspace();
   this.updatePreview();
 };
 
@@ -753,6 +772,7 @@ FactoryController.prototype.addShadow = function() {
   }
   this.view.markShadowBlock(Blockly.selected);
   this.model.addShadowBlock(Blockly.selected.id);
+  this.saveStateFromWorkspace();
   this.updatePreview();
 };
 
@@ -769,6 +789,7 @@ FactoryController.prototype.removeShadow = function() {
   }
   this.model.removeShadowBlock(Blockly.selected.id);
   this.view.unmarkShadowBlock(Blockly.selected);
+  this.saveStateFromWorkspace();
   this.updatePreview();
 };
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -53,6 +53,8 @@ FactoryController = function(toolboxWorkspace, previewWorkspace) {
   this.view = new FactoryView();
   // Generates XML for categories.
   this.generator = new FactoryGenerator(this.model);
+  // Tracks which tab is open. Toolbox tab is open when starting.
+  this.selectedTab = FactoryController.TAB_TOOLBOX;
 };
 
 /**
@@ -293,22 +295,28 @@ FactoryController.prototype.updatePreview = function() {
   // Disable events to stop updatePreview from recursively calling itself
   // through event handlers.
   Blockly.Events.disable();
-  var tree = Blockly.Options.parseToolboxTree
-      (this.generator.generateConfigXml(this.toolboxWorkspace));
-  // No categories, creates a simple flyout.
-  if (tree.getElementsByTagName('category').length == 0) {
-    if (this.previewWorkspace.toolbox_) {
-      this.reinjectPreview(tree); // Switch to simple flyout, more expensive.
+  if (this.selectedTab == FactoryController.TAB_TOOLBOX) {
+    var tree = Blockly.Options.parseToolboxTree
+        (this.generator.generateConfigXml(this.toolboxWorkspace));
+    // No categories, creates a simple flyout.
+    if (tree.getElementsByTagName('category').length == 0) {
+      if (this.previewWorkspace.toolbox_) {
+        this.reinjectPreview(tree); // Switch to simple flyout, more expensive.
+      } else {
+        this.previewWorkspace.flyout_.show(tree.childNodes);
+      }
+    // Uses categories, creates a toolbox.
     } else {
-      this.previewWorkspace.flyout_.show(tree.childNodes);
+      if (!previewWorkspace.toolbox_) {
+        this.reinjectPreview(tree); // Create a toolbox, more expensive.
+      } else {
+        this.previewWorkspace.toolbox_.populate_(tree);
+      }
     }
-  // Uses categories, creates a toolbox.
   } else {
-    if (!previewWorkspace.toolbox_) {
-      this.reinjectPreview(tree); // Create a toolbox, more expensive.
-    } else {
-      this.previewWorkspace.toolbox_.populate_(tree);
-    }
+    this.previewWorkspace.clear();
+    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
+        (this.toolboxWorkspace), this.previewWorkspace);
   }
   // Reenable events.
   Blockly.Events.enable();
@@ -702,3 +710,44 @@ FactoryController.prototype.convertShadowBlocks = function() {
     }
   }
 };
+
+FactoryController.prototype.setTab = function(tab) {
+
+  document.getElementById('tab_preload').className = tab == FactoryController.TAB_PRELOAD ?
+      'tabon' : 'taboff';
+  document.getElementById('preload_div').style.display = tab == FactoryController.TAB_PRELOAD ?
+      'block' : 'none';
+  document.getElementById('tab_toolbox').className = tab == FactoryController.TAB_TOOLBOX ?
+      'tabon' : 'taboff';
+  document.getElementById('toolbox_div').style.display = tab == FactoryController.TAB_TOOLBOX ?
+      'block' : 'none';
+
+  this.selectedTab = tab;
+  if (tab == FactoryController.TAB_TOOLBOX) {
+    this.model.savePreloadXml(this.generator.generateWorkspaceXml
+        (this.toolboxWorkspace));
+    if (this.model.hasToolbox()) {
+      Blockly.Xml.clearAndLoadElement(this.model.getSelectedId());
+    } else {
+      this.toolboxWorkspace.clear();
+      Blockly.Xml.domToWorkspace(this.model.getSelectedXml(), this.toolboxWorkspace);
+      this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
+          (this.toolboxWorkspace.getAllBlocks()));
+    }
+  } else {
+    if (this.model.getSelected()) {
+      console.log('saved');
+      this.model.getSelected().saveFromWorkspace(this.toolboxWorkspace);
+      console.log(this.model.getSelectedXml());
+    }
+    this.toolboxWorkspace.clear();
+    this.toolboxWorkspace.clearUndo();
+    Blockly.Xml.domToWorkspace(this.model.getPreloadXml(),
+        this.toolboxWorkspace);
+    this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
+        (this.toolboxWorkspace.getAllBlocks()));
+  }
+};
+
+FactoryController.TAB_TOOLBOX = 'toolbox';
+FactoryController.TAB_PRELOAD = 'preload';

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -514,17 +514,16 @@ FactoryController.prototype.loadCategory = function() {
     return;
   }
 
+  var firstCategory = !this.model.hasToolbox();
   // Copy the standard category in the model.
   var copy = standardCategory.copy();
-
-  // Add the copy in the view.
-  var tab = this.view.addCategoryRow(copy.name, copy.id,
-      !this.model.hasToolbox());
 
   // Add it to the model.
   this.model.addElementToList(copy);
 
-  // Update the view.
+  // Update the copy in the view.
+  var tab = this.view.addCategoryRow(copy.name, copy.id, firstCategory);
+
   this.addClickToSwitch(tab, copy.id);
   // Color the category tab in the view.
   if (copy.color) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -276,7 +276,8 @@ FactoryController.prototype.exportFile = function(exportMode) {
     if (this.selectedMode == FactoryController.MODE_PRELOAD) {
       // Capture any changes made by user before generating XML if in
       // preload workspace mode.
-      this.model.savePreloadXml(Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+      this.model.savePreloadXml(Blockly.Xml.workspaceToDom
+          (this.toolboxWorkspace));
     }
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateWorkspaceXml());

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -64,7 +64,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
         'id' : 'toolbox',
         'style' : 'display:none'
       });
-  if (!this.model.hasToolbox()) {
+  if (!this.model.hasElements()) {
     // Toolbox has no categories. Use XML directly from workspace.
     this.loadToHiddenWorkspaceAndSave_(this.model.getSelectedXml(), xmlDom);
   } else {

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -114,7 +114,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
   * generated shadow blocks to actual shadow blocks.
   *
   */
- FactoryGenerator.prototype.generateWorkspaceXml = function() {
+FactoryGenerator.prototype.generateWorkspaceXml = function() {
   // Load workspace XML to hidden workspace with user-generated shadow blocks
   // as actual shadow blocks.
   this.hiddenWorkspace.clear();

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -117,10 +117,10 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   * @param {!Blockly.workspace} toolboxWorkspace The workspace to load XML
   *     from.
   */
- FactoryGenerator.prototype.generateWorkspaceXml = function(toolboxWorkspace) {
+  // UPDATE CoMMENTS
+ FactoryGenerator.prototype.generateWorkspaceXml = function(rawXml) {
   this.hiddenWorkspace.clear();
-  Blockly.Xml.domToWorkspace(Blockly.Xml.workspaceToDom(toolboxWorkspace),
-      this.hiddenWorkspace);
+  Blockly.Xml.domToWorkspace(rawXml, this.hiddenWorkspace);
   this.setShadowBlocksInHiddenWorkspace_();
   return Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
  }

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -86,7 +86,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
       if (element.type == ListElement.TYPE_SEPARATOR) {
         // If the next element is a separator.
         var nextElement = goog.dom.createDom('sep');
-      } else {
+      } else if (element.type == ListElement.TYPE_CATEGORY) {
         // If the next element is a category.
         var nextElement = goog.dom.createDom('category');
         nextElement.setAttribute('name', element.name);

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -109,6 +109,14 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   return xmlDom;
  };
 
+ FactoryGenerator.prototype.generateWorkspaceXml = function(toolboxWorkspace) {
+  this.hiddenWorkspace.clear();
+  Blockly.Xml.domToWorkspace(Blockly.Xml.workspaceToDom(toolboxWorkspace),
+      this.hiddenWorkspace);
+  this.setShadowBlocksInHiddenWorkspace_();
+  return Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
+ }
+
 /**
  * Load the given XML to the hidden workspace, set any user-generated shadow
  * blocks to be actual shadow blocks, then append the XML from the workspace

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -109,6 +109,14 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   return xmlDom;
  };
 
+ /**
+  * Generates XML for the workspace (different from generateConfigXml in that
+  * it includes XY and ID attributes). Uses a workspace and converts user
+  * generated shadow blocks to actual shadow blocks.
+  *
+  * @param {!Blockly.workspace} toolboxWorkspace The workspace to load XML
+  *     from.
+  */
  FactoryGenerator.prototype.generateWorkspaceXml = function(toolboxWorkspace) {
   this.hiddenWorkspace.clear();
   Blockly.Xml.domToWorkspace(Blockly.Xml.workspaceToDom(toolboxWorkspace),

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -39,8 +39,8 @@ FactoryModel = function() {
   this.toolboxList = [];
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // Currently selected ListElement. In list if there are categories, not in
-  // list if there is only a single flyout.
+  // Currently selected ListElement. In toolboxList if there are categories, not
+  // in toolboxList if there is only a single flyout.
   this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -129,6 +129,11 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
       false : this.hasProcedureCategory;
   // Remove element.
   this.toolboxList.splice(index, 1);
+  // If removing last element from toolbox list, create empty list element
+  // for single flyout.
+  if (this.toolboxList.length == 0) {
+    this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+  }
 };
 
 /**
@@ -380,11 +385,7 @@ FactoryModel.prototype.savePreloadXml = function(xml) {
  */
 FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
-<<<<<<< d69ceb7f6d014909fb5069d601f1ffb1ec01e308
-}
-=======
 };
->>>>>>> Have basic pre-loaded workspace working
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -91,9 +91,9 @@ FactoryModel.prototype.hasProcedures = function() {
  * Determines if the user has any elements in the toolbox. Uses the length of
  * toolboxList.
  *
- * @return {boolean} True if categories exist, false otherwise.
+ * @return {boolean} True if elements exist, false otherwise.
  */
-FactoryModel.prototype.hasToolbox = function() {
+FactoryModel.prototype.hasElements = function() {
   return this.toolboxList.length > 0;
 };
 
@@ -129,17 +129,16 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
       false : this.hasProcedureCategory;
   // Remove element.
   this.toolboxList.splice(index, 1);
-  // If removing last element from toolbox list, create empty list element
-  // for single flyout.
-
 };
 
 /**
  * Sets selected to be an empty category not in toolbox list if toolbox list
  * is empty. Should be called when removing the last element from toolbox list.
+ * If the toolbox list is empty, selected stores the XML for the single flyout
+ * of blocks displayed.
  *
  */
-FactoryModel.prototype.setDefaultSelected = function() {
+FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
   if (this.toolboxList.length == 0) {
     this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   }

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -35,13 +35,15 @@
  * @constructor
  */
 FactoryModel = function() {
-  // Ordered list of ListElement objects.
+  // Ordered list of ListElement objects. Empty if there is a single flyout.
   this.toolboxList = [];
+  // ListElement for blocks in a single flyout. Null if a toolbox exists.
+  this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // Currently selected ListElement. In toolboxList if there are categories, not
-  // in toolboxList if there is only a single flyout.
-  this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+  // Currently selected ListElement. In toolboxList if there are categories, in
+  // flyout if all blocks are displayed in a single flyout.
+  this.selected = this.flyout;
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
   // Boolean for if a Procedure category has been added.
@@ -110,6 +112,8 @@ FactoryModel.prototype.addElementToList = function(element) {
       this.hasProcedureCategory;
   // Add element to toolboxList.
   this.toolboxList.push(element);
+  // Empty single flyout.
+  this.flyout = null;
 };
 
 /**
@@ -132,15 +136,14 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
 };
 
 /**
- * Sets selected to be an empty category not in toolbox list if toolbox list
- * is empty. Should be called when removing the last element from toolbox list.
- * If the toolbox list is empty, selected stores the XML for the single flyout
- * of blocks displayed.
+ * Sets selected to be an empty single flyout if toolbox list is empty. Should
+ * be called when removing the last element from toolbox list.
  *
  */
 FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
   if (this.toolboxList.length == 0) {
-    this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+    this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
+    this.selected = this.flyout;
   }
 }
 
@@ -416,6 +419,7 @@ ListElement = function(type, opt_name) {
 // List element types.
 ListElement.TYPE_CATEGORY = 'category';
 ListElement.TYPE_SEPARATOR = 'separator';
+ListElement.TYPE_FLYOUT = 'flyout';
 
 /**
  * Saves a category by updating its XML (does not save XML for
@@ -425,8 +429,8 @@ ListElement.TYPE_SEPARATOR = 'separator';
  * from.
  */
 ListElement.prototype.saveFromWorkspace = function(workspace) {
-  // Only save list elements that are categories.
-  if (this.type != ListElement.TYPE_CATEGORY) {
+  // Don't save anything from separators.
+  if (this.type == ListElement.TYPE_SEPARATOR) {
     return;
   }
   this.xml = Blockly.Xml.workspaceToDom(workspace);
@@ -441,7 +445,7 @@ ListElement.prototype.saveFromWorkspace = function(workspace) {
  */
 ListElement.prototype.changeName = function (name) {
   // Only update list elements that are categories.
-  if (this.type != ListElement.TYPE_CATEGORY) {
+  if (this.type == ListElement.TYPE_CATEGORY) {
     return;
   }
   this.name = name;

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -41,8 +41,9 @@ FactoryModel = function() {
   this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // Reference to currently selected ListElement. Stored in toolboxList if there
-  // are categories, or in flyout if blocks are displayed in a single flyout.
+  // Reference to currently selected ListElement. Stored in this.toolboxList if
+  // there are categories, or in this.flyout if blocks are displayed in a single
+  // flyout.
   this.selected = this.flyout;
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -131,10 +131,19 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
   this.toolboxList.splice(index, 1);
   // If removing last element from toolbox list, create empty list element
   // for single flyout.
+
+};
+
+/**
+ * Sets selected to be an empty category not in toolbox list if toolbox list
+ * is empty. Should be called when removing the last element from toolbox list.
+ *
+ */
+FactoryModel.prototype.setDefaultSelected = function() {
   if (this.toolboxList.length == 0) {
     this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   }
-};
+}
 
 /**
  * Moves a list element to a certain position in toolboxList by removing it

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -40,11 +40,13 @@ FactoryModel = function() {
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
   // String name of current selected list element, null if no list elements.
-  this.selected = null;
+  this.selected = new ListElement(ListElement.TYPE_CATEGORY); // make type default? update categories
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
   // Boolean for if a Procedure category has been added.
   this.hasProcedureCategory = false;
+  // XML to be pre-loaded to workspace. Empty on default;
+  this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
 };
 
 // String name of current selected list element, null if no list elements.
@@ -364,6 +366,13 @@ FactoryModel.prototype.addCustomTag = function(category, tag) {
   }
 };
 
+FactoryModel.prototype.savePreloadXml = function(xml) {
+  this.preloadXml = xml
+};
+
+FactoryModel.prototype.getPreloadXml = function() {
+  return this.preloadXml;
+}
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -39,8 +39,9 @@ FactoryModel = function() {
   this.toolboxList = [];
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // String name of current selected list element, null if no list elements.
-  this.selected = new ListElement(ListElement.TYPE_CATEGORY); // make type default? update categories
+  // Currently selected ListElement. In list if there are categories, not in
+  // list if there is only a single flyout.
+  this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
   // Boolean for if a Procedure category has been added.
@@ -48,9 +49,6 @@ FactoryModel = function() {
   // XML to be pre-loaded to workspace. Empty on default;
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
 };
-
-// String name of current selected list element, null if no list elements.
-FactoryModel.prototype.selected = null;
 
 /**
  * Given a name, determines if it is the name of a category already present.
@@ -366,13 +364,27 @@ FactoryModel.prototype.addCustomTag = function(category, tag) {
   }
 };
 
+/*
+ * Saves XML as XML to be pre-loaded into the workspace.
+ *
+ * @param {!Element} xml The XML to be saved.
+ */
 FactoryModel.prototype.savePreloadXml = function(xml) {
   this.preloadXml = xml
 };
 
+/**
+ * Gets the XML to be pre-loaded into the workspace.
+ *
+ * @return {!Element} The XML for the workspace.
+ */
 FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
+<<<<<<< d69ceb7f6d014909fb5069d601f1ffb1ec01e308
 }
+=======
+};
+>>>>>>> Have basic pre-loaded workspace working
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -41,8 +41,8 @@ FactoryModel = function() {
   this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // Currently selected ListElement. In toolboxList if there are categories, in
-  // flyout if all blocks are displayed in a single flyout.
+  // Reference to currently selected ListElement. Stored in toolboxList if there
+  // are categories, or in flyout if blocks are displayed in a single flyout.
   this.selected = this.flyout;
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
@@ -429,11 +429,11 @@ ListElement.TYPE_FLYOUT = 'flyout';
  * from.
  */
 ListElement.prototype.saveFromWorkspace = function(workspace) {
-  // Don't save anything from separators.
-  if (this.type == ListElement.TYPE_SEPARATOR) {
-    return;
+  // Only save XML for categories and flyouts.
+  if (this.type == ListElement.TYPE_FLYOUT ||
+      this.type == ListElement.TYPE_CATEGORY) {
+    this.xml = Blockly.Xml.workspaceToDom(workspace);
   }
-  this.xml = Blockly.Xml.workspaceToDom(workspace);
 };
 
 
@@ -445,7 +445,7 @@ ListElement.prototype.saveFromWorkspace = function(workspace) {
  */
 ListElement.prototype.changeName = function (name) {
   // Only update list elements that are categories.
-  if (this.type == ListElement.TYPE_CATEGORY) {
+  if (this.type != ListElement.TYPE_CATEGORY) {
     return;
   }
   this.name = name;

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -339,3 +339,21 @@ FactoryView.prototype.unmarkShadowBlock = function(block) {
     Blockly.removeClass_(block.svgGroup_, 'shadowBlock');
   }
 };
+
+/**
+ * Sets the tabs for modes according to which mode the user is currenly
+ * editing in.
+ *
+ * @param {!string} tab The type of tab being switched to
+ *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
+ */
+FactoryView.prototype.setModeSelection = function(mode) {
+  document.getElementById('tab_preload').className = mode ==
+      FactoryController.MODE_PRELOAD ? 'tabon' : 'taboff';
+  document.getElementById('preload_div').style.display = mode ==
+      FactoryController.MODE_PRELOAD ? 'block' : 'none';
+  document.getElementById('tab_toolbox').className = mode ==
+      FactoryController.MODE_TOOLBOX ? 'tabon' : 'taboff';
+  document.getElementById('toolbox_div').style.display = mode ==
+      FactoryController.MODE_TOOLBOX ? 'block' : 'none';
+};

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -344,7 +344,7 @@ FactoryView.prototype.unmarkShadowBlock = function(block) {
  * Sets the tabs for modes according to which mode the user is currenly
  * editing in.
  *
- * @param {!string} tab The type of tab being switched to
+ * @param {!string} mode The mode being switched to
  *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
  */
 FactoryView.prototype.setModeSelection = function(mode) {
@@ -356,4 +356,16 @@ FactoryView.prototype.setModeSelection = function(mode) {
       FactoryController.MODE_TOOLBOX ? 'tabon' : 'taboff';
   document.getElementById('toolbox_div').style.display = mode ==
       FactoryController.MODE_TOOLBOX ? 'block' : 'none';
+};
+
+/**
+ * Updates the help text above the workspace depending on the selected mode.
+ *
+ * @param {!string} mode The selected mode (FactoryController.MODE_TOOLBOX or
+ *    FactoryController.MODE_PRELOAD).
+ */
+FactoryView.prototype.updateHelpText = function(mode) {
+  var helpText = 'Drag your blocks into your ' + (mode ==
+      FactoryController.MODE_TOOLBOX ? 'toolbox: ' : 'pre-loaded workspace: ');
+  document.getElementById('editHelpText').textContent = helpText;
 };


### PR DESCRIPTION
Adds a tab to the top of the workspace area to allow the user to switch between editing their toolbox and editing a pre-loaded workspace where their blocks will be loaded when the page loads. Currently have tabs to switch back and forth and am updating the preview workspace. Import and export only import and export the toolbox XML (to be added in a future CL). User-generated shadow blocks are supported in the pre-loaded workspace. Changes made to index.html, style.css, controller, model, view, and generator.
![pre-loaded categories](https://cloud.githubusercontent.com/assets/18580768/17423128/3ac8368a-5a6d-11e6-8bef-8b300267481e.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/36)

<!-- Reviewable:end -->
