### PR TITLE
Workspace Factory #15: User-generated Shadow Blocks from Toolbox

### DIFF
--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -671,6 +671,11 @@ goog.require('goog.ui.ColorPicker');
         }
       }
     }
+
+    // Convert actual shadow blocks added from the toolbox to user-generated shadow blocks.
+    if (e.type == Blockly.Events.CREATE) {
+      controller.convertShadowBlocks();
+    }
   });
 
 </script>

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -655,8 +655,8 @@ goog.require('goog.ui.ColorPicker');
         if (selected != null && controller.isUserGenShadowBlock(selected.id)) {
 
         // Provide warning if shadow block is moved and is no longer a valid shadow block.
-          // Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +
-          //     ' blocks to be displayed.');
+          Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +
+              ' blocks to be displayed.');
 
           // Give editing options so that the user can make an invalid shadow block
           // a normal block.

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -655,8 +655,8 @@ goog.require('goog.ui.ColorPicker');
         if (selected != null && controller.isUserGenShadowBlock(selected.id)) {
 
         // Provide warning if shadow block is moved and is no longer a valid shadow block.
-          Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +
-              ' blocks to be displayed.');
+          // Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +
+          //     ' blocks to be displayed.');
 
           // Give editing options so that the user can make an invalid shadow block
           // a normal block.

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -456,7 +456,7 @@ FactoryController.prototype.loadCategory = function() {
   // Switch to loaded category.
   this.switchElement(copy.id);
   // Convert actual shadow blocks to user-generated shadow blocks.
-  this.convertShadowBlocks_();
+  this.convertShadowBlocks();
   // Update preview.
   this.updatePreview();
 };
@@ -553,7 +553,7 @@ FactoryController.prototype.importFromTree_ = function(tree) {
     this.toolboxWorkspace.cleanUp_();
 
     // Convert actual shadow blocks to user-generated shadow blocks.
-    this.convertShadowBlocks_();
+    this.convertShadowBlocks();
 
     // Add message to denote empty category.
     this.view.addEmptyCategoryMessage();
@@ -578,7 +578,7 @@ FactoryController.prototype.importFromTree_ = function(tree) {
         this.toolboxWorkspace.cleanUp_();
 
         // Convert actual shadow blocks to user-generated shadow blocks.
-        this.convertShadowBlocks_();
+        this.convertShadowBlocks();
 
         // Set category color.
         if (item.color) {
@@ -661,7 +661,7 @@ FactoryController.prototype.isUserGenShadowBlock = function(blockId) {
  * shadow blocks in the view but are still editable and movable.
  * @private
  */
-FactoryController.prototype.convertShadowBlocks_ = function() {
+FactoryController.prototype.convertShadowBlocks = function() {
   var blocks = this.toolboxWorkspace.getAllBlocks();
   for (var i = 0, block; block = blocks[i]; i++) {
     if (block.isShadow()) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -659,7 +659,6 @@ FactoryController.prototype.isUserGenShadowBlock = function(blockId) {
  * all real shadow blocks loaded in the workspace into user-generated shadow
  * blocks, meaning they are marked as shadow blocks by the model and appear as
  * shadow blocks in the view but are still editable and movable.
- * @private
  */
 FactoryController.prototype.convertShadowBlocks = function() {
   var blocks = this.toolboxWorkspace.getAllBlocks();

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -300,6 +300,11 @@ FactoryView.prototype.markShadowBlocks = function(blocks) {
 FactoryView.prototype.markShadowBlock = function(block) {
   // Add Blockly CSS for user-generated shadow blocks.
   Blockly.addClass_(block.svgGroup_, 'shadowBlock');
+  // If not a valid shadow block, add a warning message.
+  if (!block.getSurroundParent()) {
+      block.setWarningText('Shadow blocks must be nested inside' +
+          ' other blocks to be displayed.');
+  }
 };
 
 /**


### PR DESCRIPTION
When dragging block groups containing shadow blocks from the toolbox into the workspace, convert the actual shadow blocks to user-generated shadow blocks to allow users to edit them more easily and treat shadow blocks consistently.

Also had markShadowBlocks add a warning message to invalid shadow blocks so that on switching categories and reloading blocks, the warning messages don't disappear. 

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/38)

<!-- Reviewable:end -->
