### PR TITLE
Workspace Factory #16: Configure Options Object

### DIFF
--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -60,12 +60,13 @@ goog.require('goog.ui.ColorPicker');
   <p id="editHelpText">Drag blocks into your toolbox:</p>
   <table id='workspaceTabs'>
     <td id="tab_toolbox" class="tabon">Toolbox</td>
-    <td id="tab_preload" class="taboff">Pre-loaded Workspace</td>
+    <td id="tab_preload" class="taboff">Workspace</td>
   </table>
   <section id="toolbox_section">
     <div id="toolbox_blocks" class="content"></div>
     <div id='disable_div'></div>
   </section>
+
   <aside id="toolbox_div">
     <table id="categoryTable">
       <td id="tab_help">Your categories will appear here</td>
@@ -96,8 +97,6 @@ goog.require('goog.ui.ColorPicker');
     </div>
 
   </aside>
-  <aside id='preload_div' style='display:none'>
-  </aside>
 
   <div class='dropdown'>
     <button id="button_editShadow">Edit Block</button>
@@ -108,6 +107,42 @@ goog.require('goog.ui.ColorPicker');
       <a id='dropdown_removeShadow'>Remove Shadow</a>
     </div>
   </div>
+
+  <aside id='preload_div' style='display:none'>
+    <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
+    <form id="workspace_options">
+      <input type="checkbox" id="collapse_checkbox" checked>Collapsible Blocks<br>
+      <input type="checkbox" id="comments_checkbox" checked>Comments for Blocks<br>
+      <input type="checkbox" id="css_checkbox" checked>Use Blockly CSS<br>
+      <input type="checkbox" id="disable_checkbox" checked>Disabled Blocks<br>
+      <input type="checkbox" id="grid_checkbox" value="grid">Use Grid<br>
+      <div id="grid_options" style="display:none">
+        Spacing <input type="text" id="grid_spacing_text" value="0"><br>
+        Length <input type="text" id="grid_length_text" value="1"><br>
+        Color <input type="text" id="grid_colour_text" value="'#888'"><br>
+        <input type="checkbox" value="grid_snap_checkbox">Snap<br>
+      </div>
+      <input type="checkbox" id="maxBlocks_checkbox" checked>Infinite Number of Blocks<br>
+      <div id="maxBlocks_options" style="display:none">
+        Max Blocks <input type="text" id="maxBlocksValue_text" value="0"><br>
+      </div>
+      Path to Blockly Media <input type="text" id="media_text" value='"https://blockly-demo.appspot.com/static/media/"'><br>
+      <input type="checkbox" id="readOnly_checkbox">Read Only<br>
+      <input type="checkbox" id="rtl_checkbox">Layout with RTL<br>
+      <input type="checkbox" id="scrollbars_checkbox" checked>Scrollbars<br>
+      <input type="checkbox" id="sounds_checkbox" checked>Sounds<br>
+      <input type="checkbox" id="trashbox_checkbox" checked>Trashcan<br>
+      <input type="checkbox" id="zoom_checkbox" value="zoom">Zoom<br>
+      <div id="zoom_options" style="display:none">
+        <input type="checkbox" id="zoom_controls_checkbox">Zoom Controls<br>
+        <input type="checkbox" id="zoom_wheel_checkbox">Zoom Wheel<br>
+        Start Scale <input type="text" id="zoom_startScale_text" value="1.0"><br>
+        Max Scale <input type="text" id="zoom_maxScale_text" value="3"><br>
+        Min Scale <input type="text" id="zoom_minScale_text" value="0.3"><br>
+        Scale Speed <input type="text" id="zoom_scaleSpeed_text" value="1.2"><br>
+      </div>
+    </form>
+  </aside>
 
 </section>
 
@@ -705,6 +740,17 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   });
+
+  document.getElementById('grid_checkbox').addEventListener('change', function(e) {
+      document.getElementById('grid_options').style.display = document.getElementById('grid_checkbox').checked ? 'block' : 'none';
+  });
+  document.getElementById('zoom_checkbox').addEventListener('change', function(e) {
+      document.getElementById('zoom_options').style.display = document.getElementById('zoom_checkbox').checked ? 'block' : 'none';
+  });
+  document.getElementById('maxBlocks_checkbox').addEventListener('change', function(e) {
+      document.getElementById('maxBlocks_options').style.display = document.getElementById('maxBlocks_checkbox').checked ? 'none' : 'block';
+  });
+  //document.getElementById('zoom_checkbox').addEventListener('change',
 
 </script>
 </html>

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -111,35 +111,32 @@ goog.require('goog.ui.ColorPicker');
   <aside id='preload_div' style='display:none'>
     <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
     <form id="workspace_options">
-      <input type="checkbox" id="collapse_checkbox" name="collapse" checked>Collapsible Blocks
-      <input type="checkbox" id="comments_checkbox" name="comments" checked>Comments for Blocks
-      <input type="checkbox" id="css_checkbox" name="css" checked>Use Blockly CSS
-      <input type="checkbox" id="disable_checkbox" name="disable" checked>Disabled Blocks
-      <input type="checkbox" id="grid_checkbox" name="grid" value="grid">Use Grid
-      <div id="grid_options" style="display:none">
-        Spacing <input type="text" id="grid_spacing_text" name="spacing" value="0">
-        Length <input type="text" id="grid_length_text" name="length" value="1">
-        Color <input type="text" id="grid_colour_text" name="colour" value="'#888'">
-        <input type="checkbox" value="grid_snap_checkbox" name="snap">Snap
+      <input type="checkbox" id="collapse_checkbox" name="collapse" checked>Collapsible Blocks<br>
+      <input type="checkbox" id="comments_checkbox" name="comments" checked>Comments for Blocks<br>
+      <input type="checkbox" id="css_checkbox" name="css" checked>Use Blockly CSS<br>
+      <input type="checkbox" id="disable_checkbox" name="disable" checked>Disabled Blocks<br>
+      <input type="checkbox" id="grid_checkbox" name="grid" value="grid">Use Grid<br>
+      <div id="grid_options" name="grid" style="display:none">
+        Spacing <input type="text" id="grid_spacing_text" name="spacing" custom="number" value="0"><br>
+        Length <input type="text" id="grid_length_text" name="length" custom="number"value="1"><br>
+        Color <input type="text" id="grid_colour_text" name="colour" custom="text" value="#888"><br>
+        <input type="checkbox" value="grid_snap_checkbox" name="snap">Snap<br>
       </div>
-      <input type="checkbox" id="maxBlocks_checkbox" name="maxBlocks" checked>Infinite Number of Blocks
-      <div id="maxBlocks_options" style="display:none">
-        Max Blocks <input type="text" id="maxBlocksValue_text" name="maxBlocks" value="0">
-      </div>
-      Path to Blockly Media <input type="text" id="media_text" name="media" value='https://blockly-demo.appspot.com/static/media/'>
-      <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only
-      <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL
-      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars" checked>Scrollbars
-      <input type="checkbox" id="sounds_checkbox" name="sounds" checked>Sounds
-      <input type="checkbox" id="trashbox_checkbox" name="trashbox" checked>Trashcan
-      <input type="checkbox" id="zoom_checkbox" name="zoom" value="zoom">Zoom
-      <div id="zoom_options" style="display:none">
-        <input type="checkbox" id="zoom_controls_checkbox" name="controls">Zoom Controls
-        <input type="checkbox" id="zoom_wheel_checkbox" name="wheel">Zoom Wheel
-        Start Scale <input type="text" id="zoom_startScale_text" name="startScale" value="1.0">
-        Max Scale <input type="text" id="zoom_maxScale_text" name="maxScale" value="3">
-        Min Scale <input type="text" id="zoom_minScale_text" name="minScale" value="0.3">
-        Scale Speed <input type="text" id="zoom_scaleSpeed_text" name="scaleSpeed" value="1.2">
+      Max Blocks <input type="text" id="maxBlocksValue_text" name="maxBlocks" custom="number" value="Infinity"><br>
+      Path to Blockly Media <input type="text" id="media_text" name="media" custom="text" value='https://blockly-demo.appspot.com/static/media/'><br>
+      <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only<br>
+      <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL<br>
+      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars" checked>Scrollbars<br>
+      <input type="checkbox" id="sounds_checkbox" name="sounds" checked>Sounds<br>
+      <input type="checkbox" id="trashcan_checkbox" name="trashcan" checked>Trashcan<br>
+      <input type="checkbox" id="zoom_checkbox" name="zoom">Zoom<br>
+      <div id="zoom_options" name="zoom" style="display:none">
+        <input type="checkbox" id="zoom_controls_checkbox" name="controls">Zoom Controls<br>
+        <input type="checkbox" id="zoom_wheel_checkbox" name="wheel">Zoom Wheel<br>
+        Start Scale <input type="text" id="zoom_startScale_text" name="startScale" custom="number" value="1.0"><br>
+        Max Scale <input type="text" id="zoom_maxScale_text" name="maxScale" custom="number" value="3"><br>
+        Min Scale <input type="text" id="zoom_minScale_text" name="minScale" custom="number" value="0.3"><br>
+        Scale Speed <input type="text" id="zoom_scaleSpeed_text" name="scaleSpeed" custom="number" value="1.2"><br>
       </div>
     </form>
   </aside>
@@ -741,57 +738,142 @@ goog.require('goog.ui.ColorPicker');
     }
   });
 
+  //UNIFY
   document.getElementById('grid_checkbox').addEventListener('change', function(e) {
       document.getElementById('grid_options').style.display = document.getElementById('grid_checkbox').checked ? 'block' : 'none';
+      if (!document.getElementById('grid_checkbox').checked) {
+        controller.removeOption('grid');
+      } else {
+        var options = document.getElementById('grid_options').children;
+        for (var i = 0, option; option = options[i]; i++) {
+          if (option.type == 'checkbox') {
+            controller.setOptions(option.name, option.checked, 'grid');
+          } else {
+            var value = option.value;
+            if (type = option.getAttribute('custom') == 'number') {
+              value = parseInt(value);
+            }
+            controller.setOptions(option.name, value, 'grid');
+          }
+        }
+      }
   });
+  // MOVE TO METHOD IN CONTROLLER
   document.getElementById('zoom_checkbox').addEventListener('change', function(e) {
       document.getElementById('zoom_options').style.display = document.getElementById('zoom_checkbox').checked ? 'block' : 'none';
+      if (!document.getElementById('zoom_checkbox').checked) {
+        controller.removeOption('zoom');
+      } else {
+        var options = document.getElementById('zoom_options').children;
+        for (var i = 0, option; option = options[i]; i++) {
+          if (option.type == 'checkbox') {
+            controller.setOptions(option.name, option.checked, 'zoom');
+          } else {
+            var value = option.value;
+            if (type = option.getAttribute('custom') == 'number') {
+              value = parseInt(value);
+            }
+            controller.setOptions(option.name, value, 'zoom');
+          }
+        }
+      }
   });
-  document.getElementById('maxBlocks_checkbox').addEventListener('change', function(e) {
-      document.getElementById('maxBlocks_options').style.display = document.getElementById('maxBlocks_checkbox').checked ? 'none' : 'block';
-  });
+  // document.getElementById('maxBlocks_checkbox').addEventListener('change', function(e) {
+  //     document.getElementById('maxBlocks_options').style.display = document.getElementById('maxBlocks_checkbox').checked ? 'none' : 'block';
+  // });
 
-  document.getElementById('comments_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('comments', document.getElementById('comments_checkbox').checked);
-  });
-  document.getElementById('css_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('css', document.getElementById('css_checkbox').checked);
-  });
-  document.getElementById('disable_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('disable', document.getElementById('disable_checkbox').checked);
-  });
-  document.getElementById('readOnly_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('readOnly', document.getElementById('readOnly_checkbox').checked);
-  });
-  document.getElementById('rtl_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('rtl', document.getElementById('rtl_checkbox').checked);
-  });
-  document.getElementById('scrollbars_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('scrollbars', document.getElementById('scrollbars_checkbox').checked);
-  });
-  document.getElementById('sounds_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('sounds', document.getElementById('sounds_checkbox').checked);
-  });
-  document.getElementById('trashbox_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('trashbox', document.getElementById('trashbox_checkbox').checked);
-  });
+  // document.getElementById('comments_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('comments', document.getElementById('comments_checkbox').checked);
+  // });
+  // document.getElementById('css_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('css', document.getElementById('css_checkbox').checked);
+  // });
+  // document.getElementById('disable_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('disable', document.getElementById('disable_checkbox').checked);
+  // });
+  // document.getElementById('readOnly_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('readOnly', document.getElementById('readOnly_checkbox').checked);
+  // });
+  // document.getElementById('rtl_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('rtl', document.getElementById('rtl_checkbox').checked);
+  // });
+  // document.getElementById('scrollbars_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('scrollbars', document.getElementById('scrollbars_checkbox').checked);
+  // });
+  // document.getElementById('sounds_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('sounds', document.getElementById('sounds_checkbox').checked);
+  // });
+  // document.getElementById('trashbox_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('trashbox', document.getElementById('trashbox_checkbox').checked);
+  // });
 
   var options = document.getElementById('workspace_options').children;
   for (var i = 0, option; option = options[i]; i++) {
-    if (option.tagName != 'div' && option.name) {
+    console.log('ID: ' + option.id);
+    if (option.tagName != 'DIV' && option.name && option.name != 'grid' && option.name !='zoom') {
+      var name = option.name;
+      var id = option.id;
       if (option.type == 'checkbox') {
         controller.setOptions(option.name, option.checked);
-        option.addEventListener('change', function(option, controller) {
+        option.addEventListener('change', function(optionName, optionId) {
           return function() {
-            controller.setOptions(option.name, option.checked);
+            var checked = document.getElementById(optionId).checked;
+            console.log(checked + ' ' + optionName);
+            controller.setOptions(optionName, checked);
           };
-        }());
+        }(name, id));
       } else {
         controller.setOptions(option.name, option.value);
-        option.addEventListener('change', function(e) {
-          controller.setOptions(option.name, option.checked);
-        });
+        var type = option.getAttribute('custom');
+        option.addEventListener('change', function(optionName, optionId, optionType) {
+          return function() {
+            var value = document.getElementById(optionId).value
+            if (optionType == 'number') {
+              console.log("parsing");
+              value = parseInt(value);
+            }
+            console.log(value + ' ' + optionName);
+            controller.setOptions(optionName, value);
+          };
+        }(name, id, type));
       }
+    } else if (option.id == 'grid_options' || option.id == 'zoom_options') {
+      var subOptions = option.children;
+      console.log(option.name);
+      console.log(subOptions.length);
+      for (var j = 0, subOption; subOption = subOptions[j]; j++) {
+        if (subOption.name) {
+          var subName = subOption.name;
+          var id = subOption.id;
+          var name = option.getAttribute('name');
+          console.log(name);
+          if (subOption.type == 'checkbox') {
+            // controller.setOptions(subOption.name, subOption.checked, name);
+            subOption.addEventListener('change', function(optionName, subOptionName, subOptionId) {
+              return function() {
+                var checked = document.getElementById(subOptionId).checked;
+                console.log(checked + ' ' + optionName + ' ' + subOptionName);
+                controller.setOptions(subOptionName, checked, optionName);
+              };
+            }(name, subName, id));
+          } else {
+            // controller.setOptions(subOption.name, subOption.value, name);
+            var type = subOption.getAttribute('custom');
+            subOption.addEventListener('change', function(optionName, subOptionName, subOptionId, subOptionType) {
+              return function() {
+                var value = document.getElementById(subOptionId).value
+                if (subOptionType == 'number') {
+                  console.log("parsing");
+                  value = parseInt(value);
+                }
+                console.log(value + ' ' + subOptionName);
+                controller.setOptions(subOptionName, value, optionName);
+              };
+            }(name, subName, id, type));
+          }
+        }
+      }
+      console.log('done with iteration of for loop');
     }
   }
 

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -30,10 +30,26 @@ goog.require('goog.ui.ColorPicker');
   <tr>
     <td>
       <p>
-        <input type="file" id="input_import" class="inputfile"></input>
-        <label for="input_import">Import</label>
+        <div class="dropdown">
+        <button id="button_import">Import</button>
+        <div id="dropdownDiv_import" class="dropdown-content">
+          <input type="file" id="input_importToolbox" class="inputfile"></input>
+          <label for="input_importToolbox">Toolbox</label>
+          <input type="file" id="input_importPreload" class="inputfile"></input>
+          <label for="input_importPreload">Workspace Blocks</label>
+        </div>
+        </div>
+
+        <div class="dropdown">
         <button id="button_export">Export</button>
-        <button id="button_print">Print</button>
+        <div id="dropdownDiv_export" class="dropdown-content">
+          <a id='dropdown_exportToolbox'>Toolbox</a>
+          <a id='dropdown_exportPreload'>Workspace Blocks</a>
+          <a id='dropdown_exportAll'>All</a>
+        </div>
+        </div>
+
+        <button id="button_print">Print Toolbox</button>
         <button id="button_clear">Clear</button>
       </p>
     </td>
@@ -514,7 +530,8 @@ goog.require('goog.ui.ColorPicker');
     controller.removeElement();
   };
   var exportWrapper = function() {
-    controller.exportConfig();
+    document.getElementById('dropdownDiv_export').classList.toggle("show");
+    //controller.exportConfig();
   };
   var printWrapper = function() {
     controller.printConfig();
@@ -559,18 +576,27 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
-  var importWrapper = function(event) {
-    controller.importFile(event.target.files[0]);
+  var importWrapper = function() {  // took an event e before, need to have listener with 'change' for files
+    document.getElementById('dropdownDiv_import').classList.toggle("show");
+    //controller.importFile(event.target.files[0]);
   };
   var clearWrapper = function() {
     controller.clear();
-  }
+  };
   var editToolboxWrapper = function() {
     controller.setMode(FactoryController.MODE_TOOLBOX);
-  }
+  };
   var editPreloadWrapper = function() {
     controller.setMode(FactoryController.MODE_PRELOAD);
-  }
+  };
+  var importToolboxWrapper = function(e) {
+    controller.importFile(event.target.files[0], true);
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
+  var importPreloadWrapper = function(e) {
+    controller.importFile(event.target.files[0]), false;
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -596,8 +622,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', editShadowWrapper);
   document.getElementById('dropdown_name').addEventListener
       ('click', nameWrapper);
-  document.getElementById('input_import').addEventListener
-      ('change', importWrapper);
+  document.getElementById('button_import').addEventListener
+      ('click', importWrapper);
+  document.getElementById('input_importToolbox').addEventListener
+      ('change', importToolboxWrapper);
+  document.getElementById('input_importPreload').addEventListener
+      ('change', importPreloadWrapper);
   document.getElementById('button_clear').addEventListener
       ('click', clearWrapper);
   document.getElementById('dropdown_editShadowAdd').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -111,11 +111,12 @@ goog.require('goog.ui.ColorPicker');
 
   <aside id='preload_div' style='display:none'>
     <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
+    <button id="button_standardOptions">Standard Options</button>
     <form id="workspace_options">
-      <input type="checkbox" id="collapse_checkbox" name="collapse" checked>Collapsible Blocks<br>
-      <input type="checkbox" id="comments_checkbox" name="comments" checked>Comments for Blocks<br>
+      <input type="checkbox" id="collapse_checkbox" name="collapse">Collapsible Blocks<br>
+      <input type="checkbox" id="comments_checkbox" name="comments">Comments for Blocks<br>
       <input type="checkbox" id="css_checkbox" name="css" checked>Use Blockly CSS<br>
-      <input type="checkbox" id="disable_checkbox" name="disable" checked>Disabled Blocks<br>
+      <input type="checkbox" id="disable_checkbox" name="disable">Disabled Blocks<br>
       <input type="checkbox" id="grid_checkbox" name="grid" value="grid">Use Grid<br>
       <div id="grid_options" name="grid" style="display:none">
         Spacing <input type="text" id="grid_spacing_text" name="spacing" custom="number" value="0"><br>
@@ -127,9 +128,9 @@ goog.require('goog.ui.ColorPicker');
       Path to Blockly Media <input type="text" id="media_text" name="media" custom="text" value='https://blockly-demo.appspot.com/static/media/'><br>
       <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only<br>
       <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL<br>
-      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars" checked>Scrollbars<br>
+      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars">Scrollbars<br>
       <input type="checkbox" id="sounds_checkbox" name="sounds" checked>Sounds<br>
-      <input type="checkbox" id="trashcan_checkbox" name="trashcan" checked>Trashcan<br>
+      <input type="checkbox" id="trashcan_checkbox" name="trashcan">Trashcan<br>
       <input type="checkbox" id="zoom_checkbox" name="zoom">Zoom<br>
       <div id="zoom_options" name="zoom" style="display:none">
         <input type="checkbox" id="zoom_controls_checkbox" name="controls">Zoom Controls<br>
@@ -647,6 +648,9 @@ goog.require('goog.ui.ColorPicker');
     controller.exportXmlFile(FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
+  var standardOptionsWrapper = function() {
+    controller.setStandardOptiosn();
+  };
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -696,6 +700,8 @@ goog.require('goog.ui.ColorPicker');
       ('click', editToolboxWrapper);
   document.getElementById('tab_preload').addEventListener
       ('click', editPreloadWrapper);
+  document.getElementById('button_standardOptions').addEventListener
+      ('click', standardOptionsWrapper);
 
   // Create color picker with specific set of Blockly colors.
   var colorPicker = new goog.ui.ColorPicker();

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -531,7 +531,7 @@ goog.require('goog.ui.ColorPicker');
   };
   var exportWrapper = function() {
     document.getElementById('dropdownDiv_export').classList.toggle("show");
-    //controller.exportConfig();
+    document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var printWrapper = function() {
     controller.printConfig();
@@ -576,9 +576,9 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
-  var importWrapper = function() {  // took an event e before, need to have listener with 'change' for files
+  var importWrapper = function() {
     document.getElementById('dropdownDiv_import').classList.toggle("show");
-    //controller.importFile(event.target.files[0]);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
   };
   var clearWrapper = function() {
     controller.clear();
@@ -590,13 +590,26 @@ goog.require('goog.ui.ColorPicker');
     controller.setMode(FactoryController.MODE_PRELOAD);
   };
   var importToolboxWrapper = function(e) {
-    controller.importFile(event.target.files[0], true);
+    controller.importFile(event.target.files[0], FactoryController.MODE_TOOLBOX);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var importPreloadWrapper = function(e) {
-    controller.importFile(event.target.files[0]), false;
+    controller.importFile(event.target.files[0], FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
+  var exportToolboxWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportPreloadWrapper = function() {
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportAllWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -608,6 +621,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', separatorWrapper);
   document.getElementById('button_remove').addEventListener
       ('click', removeWrapper);
+  document.getElementById('dropdown_exportToolbox').addEventListener
+      ('click', exportToolboxWrapper);
+  document.getElementById('dropdown_exportPreload').addEventListener
+      ('click', exportPreloadWrapper);
+  document.getElementById('dropdown_exportAll').addEventListener
+      ('click', exportAllWrapper);
   document.getElementById('button_export').addEventListener
       ('click', exportWrapper);
   document.getElementById('button_print').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -41,7 +41,7 @@ goog.require('goog.ui.ColorPicker');
 </table>
 
 <section id="createDiv">
-  <p>Drag blocks into your toolbox:</p>
+  <p id="editHelpText">Drag blocks into your toolbox:</p>
   <table id='workspaceTabs'>
     <td id="tab_toolbox" class="tabon">Toolbox</td>
     <td id="tab_preload" class="taboff">Pre-loaded Workspace</td>
@@ -566,10 +566,10 @@ goog.require('goog.ui.ColorPicker');
     controller.clear();
   }
   var editToolboxWrapper = function() {
-    controller.setTab(FactoryController.TAB_TOOLBOX);
+    controller.setMode(FactoryController.MODE_TOOLBOX);
   }
   var editPreloadWrapper = function() {
-    controller.setTab(FactoryController.TAB_PRELOAD);
+    controller.setMode(FactoryController.MODE_PRELOAD);
   }
 
   document.getElementById('button_add').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -45,6 +45,7 @@ goog.require('goog.ui.ColorPicker');
         <div id="dropdownDiv_export" class="dropdown-content">
           <a id='dropdown_exportToolbox'>Toolbox</a>
           <a id='dropdown_exportPreload'>Workspace Blocks</a>
+          <a id='dropdown_exportOptions'>Inject Options</a>
           <a id='dropdown_exportAll'>All</a>
         </div>
         </div>
@@ -634,12 +635,16 @@ goog.require('goog.ui.ColorPicker');
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var exportPreloadWrapper = function() {
-    controller.exportFile(FactoryController.MODE_PRELOAD);
+    controller.exportXmlFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportOptionsWrapper = function() {
+    controller.exportOptionsFile();
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var exportAllWrapper = function() {
-    controller.exportFile(FactoryController.MODE_TOOLBOX);
-    controller.exportFile(FactoryController.MODE_PRELOAD);
+    controller.exportXmlFile(FactoryController.MODE_TOOLBOX);
+    controller.exportXmlFile(FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
 
@@ -657,6 +662,8 @@ goog.require('goog.ui.ColorPicker');
       ('click', exportToolboxWrapper);
   document.getElementById('dropdown_exportPreload').addEventListener
       ('click', exportPreloadWrapper);
+  document.getElementById('dropdown_exportOptions').addEventListener
+      ('click', exportOptionsWrapper);
   document.getElementById('dropdown_exportAll').addEventListener
       ('click', exportAllWrapper);
   document.getElementById('button_export').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -50,7 +50,7 @@ goog.require('goog.ui.ColorPicker');
         </div>
 
         <button id="button_print">Print Toolbox</button>
-        <button id="button_clear">Clear</button>
+        <button id="button_clear">Clear Toolbox</button>
       </p>
     </td>
   </tr>
@@ -581,7 +581,7 @@ goog.require('goog.ui.ColorPicker');
     document.getElementById('dropdownDiv_export').classList.remove("show");
   };
   var clearWrapper = function() {
-    controller.clear();
+    controller.clearToolbox();
   };
   var editToolboxWrapper = function() {
     controller.setMode(FactoryController.MODE_TOOLBOX);

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -111,35 +111,35 @@ goog.require('goog.ui.ColorPicker');
   <aside id='preload_div' style='display:none'>
     <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
     <form id="workspace_options">
-      <input type="checkbox" id="collapse_checkbox" checked>Collapsible Blocks<br>
-      <input type="checkbox" id="comments_checkbox" checked>Comments for Blocks<br>
-      <input type="checkbox" id="css_checkbox" checked>Use Blockly CSS<br>
-      <input type="checkbox" id="disable_checkbox" checked>Disabled Blocks<br>
-      <input type="checkbox" id="grid_checkbox" value="grid">Use Grid<br>
+      <input type="checkbox" id="collapse_checkbox" name="collapse" checked>Collapsible Blocks
+      <input type="checkbox" id="comments_checkbox" name="comments" checked>Comments for Blocks
+      <input type="checkbox" id="css_checkbox" name="css" checked>Use Blockly CSS
+      <input type="checkbox" id="disable_checkbox" name="disable" checked>Disabled Blocks
+      <input type="checkbox" id="grid_checkbox" name="grid" value="grid">Use Grid
       <div id="grid_options" style="display:none">
-        Spacing <input type="text" id="grid_spacing_text" value="0"><br>
-        Length <input type="text" id="grid_length_text" value="1"><br>
-        Color <input type="text" id="grid_colour_text" value="'#888'"><br>
-        <input type="checkbox" value="grid_snap_checkbox">Snap<br>
+        Spacing <input type="text" id="grid_spacing_text" name="spacing" value="0">
+        Length <input type="text" id="grid_length_text" name="length" value="1">
+        Color <input type="text" id="grid_colour_text" name="colour" value="'#888'">
+        <input type="checkbox" value="grid_snap_checkbox" name="snap">Snap
       </div>
-      <input type="checkbox" id="maxBlocks_checkbox" checked>Infinite Number of Blocks<br>
+      <input type="checkbox" id="maxBlocks_checkbox" name="maxBlocks" checked>Infinite Number of Blocks
       <div id="maxBlocks_options" style="display:none">
-        Max Blocks <input type="text" id="maxBlocksValue_text" value="0"><br>
+        Max Blocks <input type="text" id="maxBlocksValue_text" name="maxBlocks" value="0">
       </div>
-      Path to Blockly Media <input type="text" id="media_text" value='"https://blockly-demo.appspot.com/static/media/"'><br>
-      <input type="checkbox" id="readOnly_checkbox">Read Only<br>
-      <input type="checkbox" id="rtl_checkbox">Layout with RTL<br>
-      <input type="checkbox" id="scrollbars_checkbox" checked>Scrollbars<br>
-      <input type="checkbox" id="sounds_checkbox" checked>Sounds<br>
-      <input type="checkbox" id="trashbox_checkbox" checked>Trashcan<br>
-      <input type="checkbox" id="zoom_checkbox" value="zoom">Zoom<br>
+      Path to Blockly Media <input type="text" id="media_text" name="media" value='https://blockly-demo.appspot.com/static/media/'>
+      <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only
+      <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL
+      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars" checked>Scrollbars
+      <input type="checkbox" id="sounds_checkbox" name="sounds" checked>Sounds
+      <input type="checkbox" id="trashbox_checkbox" name="trashbox" checked>Trashcan
+      <input type="checkbox" id="zoom_checkbox" name="zoom" value="zoom">Zoom
       <div id="zoom_options" style="display:none">
-        <input type="checkbox" id="zoom_controls_checkbox">Zoom Controls<br>
-        <input type="checkbox" id="zoom_wheel_checkbox">Zoom Wheel<br>
-        Start Scale <input type="text" id="zoom_startScale_text" value="1.0"><br>
-        Max Scale <input type="text" id="zoom_maxScale_text" value="3"><br>
-        Min Scale <input type="text" id="zoom_minScale_text" value="0.3"><br>
-        Scale Speed <input type="text" id="zoom_scaleSpeed_text" value="1.2"><br>
+        <input type="checkbox" id="zoom_controls_checkbox" name="controls">Zoom Controls
+        <input type="checkbox" id="zoom_wheel_checkbox" name="wheel">Zoom Wheel
+        Start Scale <input type="text" id="zoom_startScale_text" name="startScale" value="1.0">
+        Max Scale <input type="text" id="zoom_maxScale_text" name="maxScale" value="3">
+        Min Scale <input type="text" id="zoom_minScale_text" name="minScale" value="0.3">
+        Scale Speed <input type="text" id="zoom_scaleSpeed_text" name="scaleSpeed" value="1.2">
       </div>
     </form>
   </aside>
@@ -750,7 +750,50 @@ goog.require('goog.ui.ColorPicker');
   document.getElementById('maxBlocks_checkbox').addEventListener('change', function(e) {
       document.getElementById('maxBlocks_options').style.display = document.getElementById('maxBlocks_checkbox').checked ? 'none' : 'block';
   });
-  //document.getElementById('zoom_checkbox').addEventListener('change',
+
+  document.getElementById('comments_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('comments', document.getElementById('comments_checkbox').checked);
+  });
+  document.getElementById('css_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('css', document.getElementById('css_checkbox').checked);
+  });
+  document.getElementById('disable_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('disable', document.getElementById('disable_checkbox').checked);
+  });
+  document.getElementById('readOnly_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('readOnly', document.getElementById('readOnly_checkbox').checked);
+  });
+  document.getElementById('rtl_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('rtl', document.getElementById('rtl_checkbox').checked);
+  });
+  document.getElementById('scrollbars_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('scrollbars', document.getElementById('scrollbars_checkbox').checked);
+  });
+  document.getElementById('sounds_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('sounds', document.getElementById('sounds_checkbox').checked);
+  });
+  document.getElementById('trashbox_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('trashbox', document.getElementById('trashbox_checkbox').checked);
+  });
+
+  var options = document.getElementById('workspace_options').children;
+  for (var i = 0, option; option = options[i]; i++) {
+    if (option.tagName != 'div' && option.name) {
+      if (option.type == 'checkbox') {
+        controller.setOptions(option.name, option.checked);
+        option.addEventListener('change', function(option, controller) {
+          return function() {
+            controller.setOptions(option.name, option.checked);
+          };
+        }());
+      } else {
+        controller.setOptions(option.name, option.value);
+        option.addEventListener('change', function(e) {
+          controller.setOptions(option.name, option.checked);
+        });
+      }
+    }
+  }
 
 </script>
 </html>

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -42,11 +42,15 @@ goog.require('goog.ui.ColorPicker');
 
 <section id="createDiv">
   <p>Drag blocks into your toolbox:</p>
+  <table id='workspaceTabs'>
+    <td id="tab_toolbox" class="tabon">Toolbox</td>
+    <td id="tab_preload" class="taboff">Pre-loaded Workspace</td>
+  </table>
   <section id="toolbox_section">
     <div id="toolbox_blocks" class="content"></div>
     <div id='disable_div'></div>
   </section>
-  <aside id="category_section">
+  <aside id="toolbox_div">
     <table id="categoryTable">
       <td id="tab_help">Your categories will appear here</td>
     </table>
@@ -75,7 +79,11 @@ goog.require('goog.ui.ColorPicker');
     </div>
     </div>
 
-    <div class='dropdown'>
+  </aside>
+  <aside id='preload_div' style='display:none'>
+  </aside>
+
+  <div class='dropdown'>
     <button id="button_editShadow">Edit Block</button>
     <div id="dropdown_editShadowAdd" class="dropdown-content">
       <a id='dropdown_addShadow'>Add Shadow</a>
@@ -83,9 +91,8 @@ goog.require('goog.ui.ColorPicker');
     <div id="dropdown_editShadowRemove" class="dropdown-content">
       <a id='dropdown_removeShadow'>Remove Shadow</a>
     </div>
-    </div>
+  </div>
 
-  </aside>
 </section>
 
 <aside id="previewDiv">
@@ -558,6 +565,12 @@ goog.require('goog.ui.ColorPicker');
   var clearWrapper = function() {
     controller.clear();
   }
+  var editToolboxWrapper = function() {
+    controller.setTab(FactoryController.TAB_TOOLBOX);
+  }
+  var editPreloadWrapper = function() {
+    controller.setTab(FactoryController.TAB_PRELOAD);
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -589,8 +602,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', clearWrapper);
   document.getElementById('dropdown_editShadowAdd').addEventListener
       ('click', shadowAddWrapper);
-    document.getElementById('dropdown_editShadowRemove').addEventListener
+  document.getElementById('dropdown_editShadowRemove').addEventListener
       ('click', shadowRemoveWrapper);
+  document.getElementById('tab_toolbox').addEventListener
+      ('click', editToolboxWrapper);
+  document.getElementById('tab_preload').addEventListener
+      ('click', editPreloadWrapper);
 
   // Create color picker with specific set of Blockly colors.
   var colorPicker = new goog.ui.ColorPicker();

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -111,25 +111,25 @@ goog.require('goog.ui.ColorPicker');
 
   <aside id='preload_div' style='display:none'>
     <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
-    <button id="button_standardOptions">Standard Options</button>
+    <button class="small" id="button_standardOptions">Standard Options</button>
     <form id="workspace_options">
       <input type="checkbox" id="collapse_checkbox" name="collapse">Collapsible Blocks<br>
       <input type="checkbox" id="comments_checkbox" name="comments">Comments for Blocks<br>
-      <input type="checkbox" id="css_checkbox" name="css" checked>Use Blockly CSS<br>
+      <input type="checkbox" id="css_checkbox" name="css">Use Blockly CSS<br>
       <input type="checkbox" id="disable_checkbox" name="disable">Disabled Blocks<br>
-      <input type="checkbox" id="grid_checkbox" name="grid" value="grid">Use Grid<br>
+      <input type="checkbox" id="grid_checkbox" name="grid">Use Grid<br>
       <div id="grid_options" name="grid" style="display:none">
         Spacing <input type="text" id="grid_spacing_text" name="spacing" custom="number" value="0"><br>
         Length <input type="text" id="grid_length_text" name="length" custom="number"value="1"><br>
         Color <input type="text" id="grid_colour_text" name="colour" custom="text" value="#888"><br>
-        <input type="checkbox" value="grid_snap_checkbox" name="snap">Snap<br>
+        <input type="checkbox" id="grid_snap_checkbox" value="grid_snap_checkbox" name="snap">Snap<br>
       </div>
-      Max Blocks <input type="text" id="maxBlocksValue_text" name="maxBlocks" custom="number" value="Infinity"><br>
-      Path to Blockly Media <input type="text" id="media_text" name="media" custom="text" value='https://blockly-demo.appspot.com/static/media/'><br>
+      Max Blocks <input type="text" id="maxBlocks_text" name="maxBlocks" custom="number" value="Infinity"><br>
+      Path to Blockly Media <input type="text" id="media_text" name="media" custom="text"><br>
       <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only<br>
       <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL<br>
       <input type="checkbox" id="scrollbars_checkbox" name="scrollbars">Scrollbars<br>
-      <input type="checkbox" id="sounds_checkbox" name="sounds" checked>Sounds<br>
+      <input type="checkbox" id="sounds_checkbox" name="sounds">Sounds<br>
       <input type="checkbox" id="trashcan_checkbox" name="trashcan">Trashcan<br>
       <input type="checkbox" id="zoom_checkbox" name="zoom">Zoom<br>
       <div id="zoom_options" name="zoom" style="display:none">
@@ -646,10 +646,11 @@ goog.require('goog.ui.ColorPicker');
   var exportAllWrapper = function() {
     controller.exportXmlFile(FactoryController.MODE_TOOLBOX);
     controller.exportXmlFile(FactoryController.MODE_PRELOAD);
+    controller.exportOptionsFile();
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var standardOptionsWrapper = function() {
-    controller.setStandardOptiosn();
+    controller.setStandardOptionsAndUpdate();
   };
 
   document.getElementById('button_add').addEventListener
@@ -751,144 +752,50 @@ goog.require('goog.ui.ColorPicker');
     }
   });
 
-  //UNIFY
+  // Add event listeners for checkboxes and text fields for configuring the Options object.
+
+  // Checking the grid checkbox displays and applys grid options.
+  // Unchecking the grid checkbox removes the grid object from the options object and
+  // hides the grid options.
   document.getElementById('grid_checkbox').addEventListener('change', function(e) {
       document.getElementById('grid_options').style.display = document.getElementById('grid_checkbox').checked ? 'block' : 'none';
       if (!document.getElementById('grid_checkbox').checked) {
         controller.removeOption('grid');
       } else {
-        var options = document.getElementById('grid_options').children;
-        for (var i = 0, option; option = options[i]; i++) {
-          if (option.type == 'checkbox') {
-            controller.setOptions(option.name, option.checked, 'grid');
-          } else {
-            var value = option.value;
-            if (type = option.getAttribute('custom') == 'number') {
-              value = parseInt(value);
-            }
-            controller.setOptions(option.name, value, 'grid');
-          }
-        }
+        controller.openAndApplySubOptions('grid', document.getElementById('grid_options').children);
       }
   });
-  // MOVE TO METHOD IN CONTROLLER
+
+  // Checking the zoom checkbox displays and applys grid options.
+  // Unchecking the zoom checkbox removes the zoom object from the options object and
+  // hides the zoom options.
   document.getElementById('zoom_checkbox').addEventListener('change', function(e) {
       document.getElementById('zoom_options').style.display = document.getElementById('zoom_checkbox').checked ? 'block' : 'none';
       if (!document.getElementById('zoom_checkbox').checked) {
         controller.removeOption('zoom');
       } else {
-        var options = document.getElementById('zoom_options').children;
-        for (var i = 0, option; option = options[i]; i++) {
-          if (option.type == 'checkbox') {
-            controller.setOptions(option.name, option.checked, 'zoom');
-          } else {
-            var value = option.value;
-            if (type = option.getAttribute('custom') == 'number') {
-              value = parseInt(value);
-            }
-            controller.setOptions(option.name, value, 'zoom');
-          }
-        }
+        controller.openAndApplySubOptions('zoom', document.getElementById('zoom_options').children);
       }
   });
-  // document.getElementById('maxBlocks_checkbox').addEventListener('change', function(e) {
-  //     document.getElementById('maxBlocks_options').style.display = document.getElementById('maxBlocks_checkbox').checked ? 'none' : 'block';
-  // });
 
-  // document.getElementById('comments_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('comments', document.getElementById('comments_checkbox').checked);
-  // });
-  // document.getElementById('css_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('css', document.getElementById('css_checkbox').checked);
-  // });
-  // document.getElementById('disable_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('disable', document.getElementById('disable_checkbox').checked);
-  // });
-  // document.getElementById('readOnly_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('readOnly', document.getElementById('readOnly_checkbox').checked);
-  // });
-  // document.getElementById('rtl_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('rtl', document.getElementById('rtl_checkbox').checked);
-  // });
-  // document.getElementById('scrollbars_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('scrollbars', document.getElementById('scrollbars_checkbox').checked);
-  // });
-  // document.getElementById('sounds_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('sounds', document.getElementById('sounds_checkbox').checked);
-  // });
-  // document.getElementById('trashbox_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('trashbox', document.getElementById('trashbox_checkbox').checked);
-  // });
-
+  // Add event listeners for all options checkboxes and text fields (not zoom and grid).
   var options = document.getElementById('workspace_options').children;
   for (var i = 0, option; option = options[i]; i++) {
-    console.log('ID: ' + option.id);
-    if (option.tagName != 'DIV' && option.name && option.name != 'grid' && option.name !='zoom') {
-      var name = option.name;
-      var id = option.id;
-      if (option.type == 'checkbox') {
-        controller.setOptions(option.name, option.checked);
-        option.addEventListener('change', function(optionName, optionId) {
-          return function() {
-            var checked = document.getElementById(optionId).checked;
-            console.log(checked + ' ' + optionName);
-            controller.setOptions(optionName, checked);
-          };
-        }(name, id));
-      } else {
-        controller.setOptions(option.name, option.value);
-        var type = option.getAttribute('custom');
-        option.addEventListener('change', function(optionName, optionId, optionType) {
-          return function() {
-            var value = document.getElementById(optionId).value
-            if (optionType == 'number') {
-              console.log("parsing");
-              value = parseInt(value);
-            }
-            console.log(value + ' ' + optionName);
-            controller.setOptions(optionName, value);
-          };
-        }(name, id, type));
-      }
+    if (option.name && option.getAttribute('name') != 'grid' && option.getAttribute('name') !='zoom') {
+      controller.addOptionsListener(option);
     } else if (option.id == 'grid_options' || option.id == 'zoom_options') {
+      // Add event listeners for suboptions of grid and zoom.
       var subOptions = option.children;
-      console.log(option.name);
-      console.log(subOptions.length);
       for (var j = 0, subOption; subOption = subOptions[j]; j++) {
         if (subOption.name) {
-          var subName = subOption.name;
-          var id = subOption.id;
-          var name = option.getAttribute('name');
-          console.log(name);
-          if (subOption.type == 'checkbox') {
-            // controller.setOptions(subOption.name, subOption.checked, name);
-            subOption.addEventListener('change', function(optionName, subOptionName, subOptionId) {
-              return function() {
-                var checked = document.getElementById(subOptionId).checked;
-                console.log(checked + ' ' + optionName + ' ' + subOptionName);
-                controller.setOptions(subOptionName, checked, optionName);
-              };
-            }(name, subName, id));
-          } else {
-            // controller.setOptions(subOption.name, subOption.value, name);
-            var type = subOption.getAttribute('custom');
-            subOption.addEventListener('change', function(optionName, subOptionName, subOptionId, subOptionType) {
-              return function() {
-                var value = document.getElementById(subOptionId).value
-                if (subOptionType == 'number') {
-                  console.log("parsing");
-                  value = parseInt(value);
-                }
-                console.log(value + ' ' + subOptionName);
-                controller.setOptions(subOptionName, value, optionName);
-              };
-            }(name, subName, id, type));
-          }
+          controller.addOptionsListener(subOption, option.getAttribute('name'));
         }
       }
-      console.log('done with iteration of for loop');
     }
   }
+
+  // Check standard options and apply the changes to update the view.
+  controller.setStandardOptionsAndUpdate();
 
 </script>
 </html>

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -63,6 +63,10 @@ button:hover:not(:disabled)>* {
   opacity: 1;
 }
 
+button.small {
+  font-size: small;
+}
+
 table {
   border: none;
   border-collapse: collapse;

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -21,6 +21,10 @@ aside {
   border-bottom: none;
 }
 
+#workspaceTabs>table {
+  float: right;
+}
+
 td.tabon {
   border-bottom-color: #ddd !important;
   background-color: #ddd;
@@ -135,7 +139,7 @@ td {
   width: 30%;
 }
 
-#category_section {
+#toolbox_div {
   width: 20%;
 }
 

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -112,6 +112,10 @@ td {
   width: 20%;
 }
 
+#preload_div {
+  width: 20%;
+}
+
 #disable_div {
   background-color: white;
   height: 100%;

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -63,33 +63,6 @@ button:hover:not(:disabled)>* {
   opacity: 1;
 }
 
-label {
-  border-radius: 4px;
-  border: 1px solid #ddd;
-  background-color: #eee;
-  color: #000;
-  font-size: large;
-  margin: 0 5px;
-  padding: 10px;
-}
-
-label:hover:not(:disabled) {
-  box-shadow: 2px 2px 5px #888;
-}
-
-label:disabled {
-  opacity: .6;
-}
-
-label>* {
-  opacity: .6;
-  vertical-align: text-bottom;
-}
-
-label:hover:not(:disabled)>* {
-  opacity: 1;
-}
-
 table {
   border: none;
   border-collapse: collapse;
@@ -217,8 +190,19 @@ td {
     text-decoration: none;
 }
 
+.dropdown-content label {
+    color: black;
+    display: block;
+    padding: 12px 16px;
+    text-decoration: none;
+}
+
 /* Change color of dropdown links on hover */
 .dropdown-content a:hover {
+  background-color: #f1f1f1
+}
+
+.dropdown-content label:hover {
   background-color: #f1f1f1
 }
 

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -21,10 +21,6 @@ aside {
   border-bottom: none;
 }
 
-#workspaceTabs>table {
-  float: right;
-}
-
 td.tabon {
   border-bottom-color: #ddd !important;
   background-color: #ddd;

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -283,6 +283,13 @@ FactoryController.prototype.updatePreview = function() {
         this.previewWorkspace.toolbox_.populate_(tree);
       }
     }
+
+    // Update pre-loaded blocks in the preview workspace to make sure that
+    // blocks don't get cleared when updating preview from event listeners while
+    // switching modes.
+    this.previewWorkspace.clear();
+    Blockly.Xml.domToWorkspace(this.model.getPreloadXml(),
+        this.previewWorkspace);
   } else {
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -249,7 +249,8 @@ FactoryController.prototype.exportFile = function(exportMode) {
     if (this.selectedMode == FactoryController.MODE_PRELOAD) {
       // Capture any changes made by user before generating XML if in
       // preload workspace mode.
-      this.model.savePreloadXml(Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+      this.model.savePreloadXml(Blockly.Xml.workspaceToDom
+          (this.toolboxWorkspace));
     }
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateWorkspaceXml());

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -57,10 +57,16 @@ FactoryController.prototype.addCategory = function() {
       if (!name) {  // Exit if cancelled.
         return;
       }
+      // Create the new category.
       this.createCategory(name, true);
+      // Allow the user to use the default options for injecting the workspace
+      // when there are categories.
+      this.allowToSetDefaultCategoryOptions();
+      // Set the new category as selected.
       this.model.setSelectedById(this.model.getCategoryIdByName(name));
     }
   }
+
   // After possibly creating a category, check again if it's the first category.
   firstCategory = !this.model.hasToolbox();
   // Get name from user.
@@ -72,6 +78,11 @@ FactoryController.prototype.addCategory = function() {
   this.createCategory(name, firstCategory);
   // Switch to category.
   this.switchElement(this.model.getCategoryIdByName(name));
+   // Allow the user to use the default options for injecting the workspace
+  // when there are categories if adding the first category.
+  if (firstCategory) {
+    this.allowToSetDefaultCategoryOptions();
+  }
   // Update preview.
   this.updatePreview();
 };
@@ -157,6 +168,9 @@ FactoryController.prototype.removeElement = function() {
     this.toolboxWorkspace.clear();
     this.toolboxWorkspace.clearUndo();
     this.model.setDefaultSelected();
+    // Allow the user to use the default options for injecting the workspace
+    // when there are no categories.
+    this.allowToSetDefaultFlyoutOptions();
   }
 
   // Update preview.
@@ -525,6 +539,11 @@ FactoryController.prototype.loadCategory = function() {
   this.switchElement(copy.id);
   // Convert actual shadow blocks to user-generated shadow blocks.
   this.convertShadowBlocks_();
+  if (firstCategory) {
+    // Allow the user to use the default options for injecting the workspace
+    // when there are categories.
+    this.allowToSetDefaultCategoryOptions();
+  }
   // Update preview.
   this.updatePreview();
 };
@@ -643,9 +662,14 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
 
     // Add message to denote empty category.
     this.view.addEmptyCategoryMessage();
+
+    // Allow the user to set the default configuration options for a single
+    // flyout.
+    this.allowToSetDefaultFlyoutOptions();
   } else {
     // Categories/separators present.
     for (var i = 0, item; item = tree.children[i]; i++) {
+
       if (item.tagName == 'category') {
         // If the element is a category, create a new category and switch to it.
         this.createCategory(item.getAttribute('name'), false);
@@ -676,6 +700,10 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
         this.switchElement(this.model.getElementByIndex(i).id);
       }
     }
+
+    // Allow the user to set the default configuration options for using
+    // categories.
+    this.allowToSetDefaultCategoryOptions();
   }
 
   this.updatePreview();
@@ -701,11 +729,15 @@ FactoryController.prototype.importPreloadFromTree_ = function(tree) {
  */
 FactoryController.prototype.clearToolbox = function() {
   this.setMode(FactoryController.MODE_TOOLBOX);
+  var hasCategories = this.model.hasToolbox();
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
   this.view.addEmptyCategoryMessage();
   this.toolboxWorkspace.clear();
   this.toolboxWorkspace.clearUndo();
+  if (hasCategories) {
+    this.allowToSetDefaultFlyoutOptions();
+  }
   this.updatePreview();
 };
 
@@ -832,6 +864,40 @@ FactoryController.prototype.setOptions = function(type, value,
 
 FactoryController.prototype.removeOption = function(type) {
   this.model.removeOption(type);
+  this.reinjectPreview(Blockly.Options.parseToolboxTree
+        (this.generator.generateToolboxXml()));
+};
+
+FactoryController.prototype.allowToSetDefaultFlyoutOptions = function() {
+  if (this.model.hasToolbox()) {
+    return;
+  }
+  if (!confirm('Do you want to use the default workspace configuration ' +
+          'options for injecting a workspace without categories?')) {
+    return;
+  }
+  this.model.setOption('collapse', false);
+  this.model.setOption('comments', false);
+  this.model.setOption('disable', false);
+  this.model.setOption('scrollbars', false);
+  this.model.setOption('trashcan', false);
+  this.reinjectPreview(Blockly.Options.parseToolboxTree
+        (this.generator.generateToolboxXml()));
+};
+
+FactoryController.prototype.allowToSetDefaultCategoryOptions = function() {
+  if (!this.model.hasToolbox()) {
+    return;
+  }
+  if (!confirm('Do you want to use the default workspace configuration ' +
+          'options for injecting a workspace with categories?')) {
+    return;
+  }
+  this.model.setOption('collapse', true);
+  this.model.setOption('comments', true);
+  this.model.setOption('disable', true);
+  this.model.setOption('scrollbars', true);
+  this.model.setOption('trashcan', true);
   this.reinjectPreview(Blockly.Options.parseToolboxTree
         (this.generator.generateToolboxXml()));
 }

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -288,13 +288,14 @@ FactoryController.prototype.updatePreview = function() {
     // blocks don't get cleared when updating preview from event listeners while
     // switching modes.
     this.previewWorkspace.clear();
-    Blockly.Xml.domToWorkspace(this.model.getPreloadXml(),
-        this.previewWorkspace);
+    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
+        (this.model.getPreloadXml()), this.previewWorkspace);
   } else {
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
-        (this.toolboxWorkspace), this.previewWorkspace);
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)),
+        this.previewWorkspace);
   }
   // Reenable events.
   Blockly.Events.enable();
@@ -516,7 +517,8 @@ FactoryController.prototype.addSeparator = function() {
  * @param {string} file The path for the file to be imported into the workspace.
  * Should contain valid toolbox XML.
  */
-FactoryController.prototype.importFile = function(file) {
+ // UPDATE COMMENTS
+FactoryController.prototype.importFile = function(file, isToolbox) {
   // Exit if cancelled.
   if (!file) {
     return;
@@ -527,12 +529,20 @@ FactoryController.prototype.importFile = function(file) {
   reader.onload = function() {
     // Try to parse XML from file and load it into toolbox editing area.
     // Print error message if fail.
-    try {
+    //try {
       var tree = Blockly.Xml.textToDom(reader.result);
-      controller.importFromTree_(tree);
-    } catch(e) {
-      alert('Cannot load XML from file.');
-    }
+      if (isToolbox) {
+        controller.setMode(FactoryController.MODE_TOOLBOX);
+        controller.importToolboxFromTree_(tree);
+      } else {
+        controller.setMode(FactoryController.MODE_PRELOAD);
+        controller.importPreloadFromTree_(tree);
+      }
+    // } catch(e) {
+    //   alert('Cannot load XML from file.');
+    //   console.log(e);
+    //   console.log(e.lineno);
+    // }
   }
 
   // Read the file.
@@ -547,7 +557,7 @@ FactoryController.prototype.importFile = function(file) {
  *
  * @param {!Element} tree XML tree to be loaded to toolbox editing area.
  */
-FactoryController.prototype.importFromTree_ = function(tree) {
+FactoryController.prototype.importToolboxFromTree_ = function(tree) {
   // Clear current editing area.
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
@@ -600,6 +610,14 @@ FactoryController.prototype.importFromTree_ = function(tree) {
 
   this.updatePreview();
 };
+
+FactoryController.prototype.importPreloadFromTree_ = function(tree) {
+  this.clearAndLoadXml_(tree);
+  this.model.savePreloadXml(tree);
+  this.updatePreview(); //assuming that updatePreview still calls domToWorkspace regardless of mode
+  // this.previewWorkspace.domToWorkspace
+  //     (this.generator.generateWorkspaceXml(tree));
+}
 
 /**
  * Clears the toolbox editing area completely, deleting all categories and all
@@ -676,6 +694,11 @@ FactoryController.prototype.convertShadowBlocks_ = function() {
  */
 FactoryController.prototype.setMode = function(mode) {
 
+  // No work to change mode that's currently set.
+  if (this.selectedMode == mode) {
+    return;
+  }
+
   // Set tab selection and display appropriate tab.
   this.view.setModeSelection(mode);
 
@@ -687,7 +710,7 @@ FactoryController.prototype.setMode = function(mode) {
     document.getElementById('editHelpText').textContent =
         'Drag blocks into your toolbox:';
     this.model.savePreloadXml(this.generator.generateWorkspaceXml
-        (this.toolboxWorkspace));
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)));
     this.clearAndLoadXml_(this.model.getSelectedXml());
     this.view.disableWorkspace(this.view.shouldDisableWorkspace
         (this.model.getSelected()));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -807,6 +807,10 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
       (this.toolboxWorkspace.getAllBlocks()));
 }
 
+FactoryController.prototype.setOptions = function(type, value) {
+  this.model.setOptions(type, value);
+};
+
 // Toolbox editing mode. Changes the user makes to the workspace updates the
 // toolbox.
 FactoryController.MODE_TOOLBOX = 'toolbox';

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -124,30 +124,41 @@ FactoryController.prototype.removeElement = function() {
   if (!this.model.getSelected()) {
     return;
   }
+
   // Check if user wants to remove current category.
   var check = confirm('Are you sure you want to delete the currently selected '
         + this.model.getSelected().type + '?');
   if (!check) { // If cancelled, exit.
     return;
   }
+
   var selectedId = this.model.getSelectedId();
   var selectedIndex = this.model.getIndexByElementId(selectedId);
   // Delete element visually.
   this.view.deleteElementRow(selectedId, selectedIndex);
   // Delete element in model.
   this.model.deleteElementFromList(selectedIndex);
+
   // Find next logical element to switch to.
   var next = this.model.getElementByIndex(selectedIndex);
   if (!next && this.model.hasToolbox()) {
     next = this.model.getElementByIndex(selectedIndex - 1);
   }
   var nextId = next ? next.id : null;
+
   // Open next element.
   this.clearAndLoadElement(nextId);
+
+  // If no element to switch to, display message, clear the workspace, and
+  // set a default selected element not in toolbox list in the model.
   if (!nextId) {
     alert('You currently have no categories or separators. All your blocks' +
         ' will be displayed in a single flyout.');
+    this.toolboxWorkspace.clear();
+    this.toolboxWorkspace.clearUndo();
+    this.model.setDefaultSelected();
   }
+
   // Update preview.
   this.updatePreview();
 };
@@ -208,17 +219,21 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
     this.view.disableWorkspace(false);
   }
 
-  // Set next category.
-  this.model.setSelectedById(id);
+  // If switching to another category, set category selection in the model and
+  // view.
+  if (id != null) {
+    // Set next category.
+    this.model.setSelectedById(id);
 
-  // Clears workspace and loads next category.
-  this.clearAndLoadXml_(this.model.getSelectedXml());
+    // Clears workspace and loads next category.
+    this.clearAndLoadXml_(this.model.getSelectedXml());
 
-  // Selects the next tab.
-  this.view.setCategoryTabSelection(id, true);
+    // Selects the next tab.
+    this.view.setCategoryTabSelection(id, true);
 
-  // Order blocks as if shown in the flyout.
-  this.toolboxWorkspace.cleanUp_();
+    // Order blocks as if shown in the flyout.
+    this.toolboxWorkspace.cleanUp_();
+  }
 
   // Update category editing buttons.
   this.view.updateState(this.model.getIndexByElementId
@@ -671,9 +686,10 @@ FactoryController.prototype.importPreloadFromTree_ = function(tree) {
 
 /**
  * Clears the toolbox editing area completely, deleting all categories and all
- * blocks in the model and view.
+ * blocks in the model and view. Sets the mode to toolbox mode.
  */
-FactoryController.prototype.clear = function() {
+FactoryController.prototype.clearToolbox = function() {
+  this.setMode(FactoryController.MODE_TOOLBOX);
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
   this.view.addEmptyCategoryMessage();

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -361,19 +361,20 @@ FactoryController.prototype.updatePreview = function() {
  */
 FactoryController.prototype.reinjectPreview = function(tree) {
   this.previewWorkspace.dispose();
-  previewToolbox = Blockly.Xml.domToPrettyText(tree);
-  this.previewWorkspace = Blockly.inject('preview_blocks',
-    {grid:
-      {spacing: 25,
-       length: 3,
-       colour: '#ccc',
-       snap: true},
-     media: '../../../media/',
-     toolbox: previewToolbox,
-     zoom:
-       {controls: true,
-        wheel: true}
-    });
+  this.model.setOption('toolbox', Blockly.Xml.domToPrettyText(tree));
+  this.previewWorkspace = Blockly.inject('preview_blocks', this.model.options);
+   // this.previewWorkspace = Blockly.inject('preview_blocks',
+   //   {grid:
+   //     {spacing: 25,
+   //      length: 3,
+   //      colour: '#ccc',
+   //      snap: true},
+   //    media: '../../../media/',
+   //    toolbox: previewToolbox,
+   //    zoom:
+   //      {controls: true,
+   //       wheel: true}
+   //   });
 };
 
 /**
@@ -807,9 +808,23 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
       (this.toolboxWorkspace.getAllBlocks()));
 }
 
-FactoryController.prototype.setOptions = function(type, value) {
-  this.model.setOptions(type, value);
+FactoryController.prototype.setOptions = function(type, value,
+    opt_parentOption) {
+  if (!opt_parentOption) {
+    this.model.setOption(type, value);
+  } else {
+    console.log("calling suboption for " + opt_parentOption);
+    this.model.setSubOption(opt_parentOption, type, value);
+  }
+  this.reinjectPreview(Blockly.Options.parseToolboxTree
+        (this.generator.generateToolboxXml()));
 };
+
+FactoryController.prototype.removeOption = function(type) {
+  this.model.removeOption(type);
+  this.reinjectPreview(Blockly.Options.parseToolboxTree
+        (this.generator.generateToolboxXml()));
+}
 
 // Toolbox editing mode. Changes the user makes to the workspace updates the
 // toolbox.

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -248,7 +248,7 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
  *    (FactoryController.MODE_TOOLBOX for the toolbox configuration, and
  *    FactoryController.MODE_PRELOAD for the pre-loaded workspace configuration)
  */
-FactoryController.prototype.exportFile = function(exportMode) {
+FactoryController.prototype.exportXmlFile = function(exportMode) {
   // Generate XML.
   if (exportMode == FactoryController.MODE_TOOLBOX) {
     // Export the toolbox XML.
@@ -285,6 +285,16 @@ FactoryController.prototype.exportFile = function(exportMode) {
   var data = new Blob([configXml], {type: 'text/xml'});
   this.view.createAndDownloadFile(fileName, data);
  };
+
+FactoryController.prototype.exportOptionsFile = function() {
+  var fileName = prompt('File Name for options object for injecting: ');
+  if (!fileName) {  // If cancelled.
+    return;
+  }
+  // Prettify?
+  var data = new Blob([JSON.stringify(this.model.options)], {type: 'text/plain'});
+  this.view.createAndDownloadFile(fileName, data);
+};
 
 /**
  * Tied to "Print" button. Mainly used for debugging purposes. Prints

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -33,8 +33,8 @@ FactoryController = function(toolboxWorkspace, previewWorkspace) {
   this.view = new FactoryView();
   // Generates XML for categories.
   this.generator = new FactoryGenerator(this.model);
-  // Tracks which tab is open. Toolbox tab is open when starting.
-  this.selectedTab = FactoryController.TAB_TOOLBOX;
+  // Tracks which editing mode the user is in. Toolbox mode on start.
+  this.selectedMode = FactoryController.MODE_TOOLBOX;
 };
 
 /**
@@ -211,24 +211,13 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
   // Set next category.
   this.model.setSelectedById(id);
 
-  // Clear workspace.
-  this.toolboxWorkspace.clear();
-  this.toolboxWorkspace.clearUndo();
+  // Clears workspace and loads next category.
+  this.clearAndLoadXml_(this.model.getSelectedXml());
 
-  // Loads next category if switching to an element.
-  if (id != null) {
-    this.view.setCategoryTabSelection(id, true);
-    Blockly.Xml.domToWorkspace(this.model.getSelectedXml(),
-        this.toolboxWorkspace);
-    // Disable workspace if switching to a separator.
-    if (this.model.getSelected().type == ListElement.TYPE_SEPARATOR) {
-      this.view.disableWorkspace(true);
-    }
-  }
+  // Selects the next tab.
+  this.view.setCategoryTabSelection(id, true);
 
-  // Mark all shadow blocks laoded and order blocks as if shown in a flyout.
-  this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
-        (toolboxWorkspace.getAllBlocks()));
+  // Order blocks as if shown in the flyout.
   this.toolboxWorkspace.cleanUp_();
 
   // Update category editing buttons.
@@ -275,7 +264,8 @@ FactoryController.prototype.updatePreview = function() {
   // Disable events to stop updatePreview from recursively calling itself
   // through event handlers.
   Blockly.Events.disable();
-  if (this.selectedTab == FactoryController.TAB_TOOLBOX) {
+  if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
+    // If currently editing the toolbox.
     var tree = Blockly.Options.parseToolboxTree
         (this.generator.generateConfigXml(this.toolboxWorkspace));
     // No categories, creates a simple flyout.
@@ -294,6 +284,7 @@ FactoryController.prototype.updatePreview = function() {
       }
     }
   } else {
+    // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
         (this.toolboxWorkspace), this.previewWorkspace);
@@ -668,43 +659,61 @@ FactoryController.prototype.convertShadowBlocks_ = function() {
   }
 };
 
-FactoryController.prototype.setTab = function(tab) {
+/**
+ * Sets the currently selected mode that determines what the toolbox workspace
+ * is being used to edit. Updates the view and then saves and loads XML
+ * to and from the toolbox and updates the help text.
+ *
+ * @param {!string} tab The type of tab being switched to
+ *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
+ */
+FactoryController.prototype.setMode = function(mode) {
 
-  document.getElementById('tab_preload').className = tab == FactoryController.TAB_PRELOAD ?
-      'tabon' : 'taboff';
-  document.getElementById('preload_div').style.display = tab == FactoryController.TAB_PRELOAD ?
-      'block' : 'none';
-  document.getElementById('tab_toolbox').className = tab == FactoryController.TAB_TOOLBOX ?
-      'tabon' : 'taboff';
-  document.getElementById('toolbox_div').style.display = tab == FactoryController.TAB_TOOLBOX ?
-      'block' : 'none';
+  // Set tab selection and display appropriate tab.
+  this.view.setModeSelection(mode);
 
-  this.selectedTab = tab;
-  if (tab == FactoryController.TAB_TOOLBOX) {
+  // Update selected tab.
+  this.selectedMode = mode;
+
+  if (mode == FactoryController.MODE_TOOLBOX) {
+    // Open the toolbox editing space.
+    document.getElementById('editHelpText').textContent =
+        'Drag blocks into your toolbox:';
     this.model.savePreloadXml(this.generator.generateWorkspaceXml
         (this.toolboxWorkspace));
-    if (this.model.hasToolbox()) {
-      Blockly.Xml.clearAndLoadElement(this.model.getSelectedId());
-    } else {
-      this.toolboxWorkspace.clear();
-      Blockly.Xml.domToWorkspace(this.model.getSelectedXml(), this.toolboxWorkspace);
-      this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
-          (this.toolboxWorkspace.getAllBlocks()));
-    }
+    this.clearAndLoadXml_(this.model.getSelectedXml());
+    this.view.disableWorkspace(this.view.shouldDisableWorkspace
+        (this.model.getSelected()));
   } else {
+    // Open the pre-loaded workspace editing space.
+    document.getElementById('editHelpText').textContent =
+        'Drag blocks into your pre-loaded workspace:';
     if (this.model.getSelected()) {
-      console.log('saved');
       this.model.getSelected().saveFromWorkspace(this.toolboxWorkspace);
-      console.log(this.model.getSelectedXml());
     }
-    this.toolboxWorkspace.clear();
-    this.toolboxWorkspace.clearUndo();
-    Blockly.Xml.domToWorkspace(this.model.getPreloadXml(),
-        this.toolboxWorkspace);
-    this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
-        (this.toolboxWorkspace.getAllBlocks()));
+    this.clearAndLoadXml_(this.model.getPreloadXml());
+    this.view.disableWorkspace(false);
   }
 };
 
-FactoryController.TAB_TOOLBOX = 'toolbox';
-FactoryController.TAB_PRELOAD = 'preload';
+/**
+ * Clears the toolbox workspace and loads XML to it, marking shadow blocks
+ * as necessary.
+ * @private
+ *
+ * @param {!Element} xml The XML to be loaded to the workspace.
+ */
+FactoryController.prototype.clearAndLoadXml_ = function(xml) {
+  this.toolboxWorkspace.clear();
+  this.toolboxWorkspace.clearUndo();
+  Blockly.Xml.domToWorkspace(xml, this.toolboxWorkspace);
+  this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
+      (this.toolboxWorkspace.getAllBlocks()));
+}
+
+// Toolbox editing mode. Changes the user makes to the workspace updates the
+// toolbox.
+FactoryController.MODE_TOOLBOX = 'toolbox';
+// Pre-loaded workspace editing mode. Changes the user makes to the workspace
+// udpates the pre-loaded blocks.
+FactoryController.MODE_PRELOAD = 'preload';

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -61,7 +61,7 @@ FactoryController.prototype.addCategory = function() {
       this.createCategory(name, true);
       // Allow the user to use the default options for injecting the workspace
       // when there are categories.
-      this.allowToSetDefaultCategoryOptions();
+      this.allowToSetDefaultOptions();
       // Set the new category as selected.
       this.model.setSelectedById(this.model.getCategoryIdByName(name));
     }
@@ -81,7 +81,7 @@ FactoryController.prototype.addCategory = function() {
    // Allow the user to use the default options for injecting the workspace
   // when there are categories if adding the first category.
   if (firstCategory) {
-    this.allowToSetDefaultCategoryOptions();
+    this.allowToSetDefaultOptions();
   }
   // Update preview.
   this.updatePreview();
@@ -170,7 +170,7 @@ FactoryController.prototype.removeElement = function() {
     this.model.setDefaultSelected();
     // Allow the user to use the default options for injecting the workspace
     // when there are no categories.
-    this.allowToSetDefaultFlyoutOptions();
+    this.allowToSetDefaultOptions();
   }
 
   // Update preview.
@@ -300,13 +300,18 @@ FactoryController.prototype.exportXmlFile = function(exportMode) {
   this.view.createAndDownloadFile(fileName, data);
  };
 
+/**
+ * Export the options object to be used for the Blockly inject call. Gets a
+ * file name from the user and downloads the options object to that file.
+ */
 FactoryController.prototype.exportOptionsFile = function() {
   var fileName = prompt('File Name for options object for injecting: ');
   if (!fileName) {  // If cancelled.
     return;
   }
-  // Prettify?
-  var data = new Blob([JSON.stringify(this.model.options)], {type: 'text/plain'});
+  // TODO(evd2014): Use Regex to prettify JSON generated.
+  var data = new Blob([JSON.stringify(this.model.options)],
+      {type: 'text/plain'});
   this.view.createAndDownloadFile(fileName, data);
 };
 
@@ -387,18 +392,6 @@ FactoryController.prototype.reinjectPreview = function(tree) {
   this.previewWorkspace.dispose();
   this.model.setOption('toolbox', Blockly.Xml.domToPrettyText(tree));
   this.previewWorkspace = Blockly.inject('preview_blocks', this.model.options);
-   // this.previewWorkspace = Blockly.inject('preview_blocks',
-   //   {grid:
-   //     {spacing: 25,
-   //      length: 3,
-   //      colour: '#ccc',
-   //      snap: true},
-   //    media: '../../../media/',
-   //    toolbox: previewToolbox,
-   //    zoom:
-   //      {controls: true,
-   //       wheel: true}
-   //   });
 };
 
 /**
@@ -542,7 +535,7 @@ FactoryController.prototype.loadCategory = function() {
   if (firstCategory) {
     // Allow the user to use the default options for injecting the workspace
     // when there are categories.
-    this.allowToSetDefaultCategoryOptions();
+    this.allowToSetDefaultOptions();
   }
   // Update preview.
   this.updatePreview();
@@ -665,7 +658,7 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
 
     // Allow the user to set the default configuration options for a single
     // flyout.
-    this.allowToSetDefaultFlyoutOptions();
+    this.allowToSetDefaultOptions();
   } else {
     // Categories/separators present.
     for (var i = 0, item; item = tree.children[i]; i++) {
@@ -703,7 +696,7 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
 
     // Allow the user to set the default configuration options for using
     // categories.
-    this.allowToSetDefaultCategoryOptions();
+    this.allowToSetDefaultOptions();
   }
 
   this.updatePreview();
@@ -736,7 +729,7 @@ FactoryController.prototype.clearToolbox = function() {
   this.toolboxWorkspace.clear();
   this.toolboxWorkspace.clearUndo();
   if (hasCategories) {
-    this.allowToSetDefaultFlyoutOptions();
+    this.allowToSetDefaultOptions();
   }
   this.updatePreview();
 };
@@ -850,7 +843,20 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
       (this.toolboxWorkspace.getAllBlocks()));
 }
 
-FactoryController.prototype.setOptions = function(type, value,
+/**
+ * Sets an attribute in the options object in the model of type with the value
+ * 'value'. Optional parent option if the attribute should be an attribute
+ * of an object inside of the options object (grid or zoom). Updates the
+ * preview workspace after adding.
+ *
+ * @param {!string} type The name of the attribute to set in the options object
+ *    (or an object inside of options).
+ * @param {Object} value The value of the attribute called type.
+ * @param {!string} opt_parentOption Optional attribute inside of the options
+ *    object to which the new attribute should be added. Must have an object
+ *    as a value.
+ */
+FactoryController.prototype.setOptionAndUpdate = function(type, value,
     opt_parentOption) {
   if (!opt_parentOption) {
     this.model.setOption(type, value);
@@ -862,45 +868,160 @@ FactoryController.prototype.setOptions = function(type, value,
         (this.generator.generateToolboxXml()));
 };
 
+/**
+ * Removes an attribute 'type' from the options object and updates the preview
+ * workspace.
+ *
+ * @param {!string} type The name of the attribute in the options objec to
+ *    remove.
+ */
 FactoryController.prototype.removeOption = function(type) {
   this.model.removeOption(type);
   this.reinjectPreview(Blockly.Options.parseToolboxTree
         (this.generator.generateToolboxXml()));
 };
 
-FactoryController.prototype.allowToSetDefaultFlyoutOptions = function() {
-  if (this.model.hasToolbox()) {
+/**
+ * Sets the standard default options for the options object and updates
+ * the preview workspace. The default values depends on if categories are
+ * present.
+ */
+FactoryController.prototype.setStandardOptionsAndUpdate = function() {
+  this.setBaseOptions();
+  this.setCategoryOptions();
+  this.reinjectPreview(Blockly.Options.parseToolboxTree
+        (this.generator.generateToolboxXml()));
+ };
+
+/**
+ * Asks the user if they want to use default configuration options specific
+ * to categories or a single flyout of blocks. If desired, makes the necessary
+ * changes to the options object depending on if there are categories and then
+ * updates the preview workspace. Only updates category/flyout specific
+ * options, not the base default options that are set regardless of if
+ * categories or a single flyout are used.
+ */
+FactoryController.prototype.allowToSetDefaultOptions = function() {
+  if (!this.model.hasToolbox() && !confirm('Do you want to use the default ' +
+      'workspace configuration options for injecting a workspace without ' +
+      'categories?')) {
+    return;
+  } else if (this.model.hasToolbox() && !confirm('Do you want to use the ' +
+      'default workspace configuration options for injecting a workspace ' +
+      'with categories?')) {
     return;
   }
-  if (!confirm('Do you want to use the default workspace configuration ' +
-          'options for injecting a workspace without categories?')) {
-    return;
-  }
-  this.model.setOption('collapse', false);
-  this.model.setOption('comments', false);
-  this.model.setOption('disable', false);
-  this.model.setOption('scrollbars', false);
-  this.model.setOption('trashcan', false);
+  this.setCategoryOptions();
   this.reinjectPreview(Blockly.Options.parseToolboxTree
         (this.generator.generateToolboxXml()));
 };
 
-FactoryController.prototype.allowToSetDefaultCategoryOptions = function() {
-  if (!this.model.hasToolbox()) {
+/**
+ * Sets the basic options that are not dependent on if there are categories
+ * or a single flyout of blocks. Updates checkboxes and text fields and the
+ * model, but not the preview workspace.
+ */
+FactoryController.prototype.setBaseOptions = function() {
+  this.model.setOption('css', true);
+  document.getElementById('css_checkbox').checked = true;
+  this.model.setOption('maxBlocks', Infinity);
+  document.getElementById('maxBlocks_text').value = Infinity;
+  this.model.setOption('media',
+      'https://blockly-demo.appspot.com/static/media/');
+  document.getElementById('media_text').value =
+      'https://blockly-demo.appspot.com/static/media/';
+  this.model.setOption('readOnly', false);
+  document.getElementById('readOnly_checkbox').checked = false;
+  this.model.setOption('rtl', false);
+  document.getElementById('rtl_checkbox').checked = false;
+  this.model.setOption('sounds', true);
+  document.getElementById('sounds_checkbox').checked = true;
+};
+
+/**
+ * Updates category specific options depending on if there are categories
+ * currently present. Updates checkboxes and text fields and the model, but
+ * not the preview workspace.
+ */
+FactoryController.prototype.setCategoryOptions = function() {
+  var hasCategories = this.model.hasToolbox();
+  this.model.setOption('collapse', hasCategories);
+  document.getElementById('collapse_checkbox').checked = hasCategories;
+  this.model.setOption('comments', hasCategories);
+  document.getElementById('comments_checkbox').checked = hasCategories;
+  this.model.setOption('disable', hasCategories);
+  document.getElementById('disable_checkbox').checked = hasCategories;
+  this.model.setOption('scrollbars', hasCategories);
+  document.getElementById('scrollbars_checkbox').checked = hasCategories;
+  this.model.setOption('trashcan', hasCategories);
+  document.getElementById('trashcan_checkbox').checked = hasCategories;
+};
+
+/**
+ * Applies all suboptions of an object within the options object. Should
+ * be called when the 'grid' or 'zoom' boxes are checked.
+ *
+ * @param {!string} name The name of the object within the options object
+ *    where the suboptions should be added.
+ * @param {!Array<!Element>} options The DOM elements for the suboptions that
+ *    should be applied to the object within the options object.
+ */
+FactoryController.prototype.applySubOptions = function(name, options) {
+  for (var i = 0, option; option = options[i]; i++) {
+    if (option.type == 'checkbox') {
+      this.setOptionAndUpdate(option.name, option.checked, name);
+    } else if (option.type == 'text') {
+      var value = option.value;
+      if (type = option.getAttribute('custom') == 'number') {
+        value = parseInt(value);
+      }
+      this.setOptionAndUpdate(option.name, value, name);
+    }
+  }
+};
+
+/**
+ * Adds event listeners for a checkbox or text input field associated
+ * with the options object. The input can modify a top-level attribute within
+ * the options object or an attribute of an object inside the options object
+ * (with the name opt_parentName).
+ *
+ * @param {!Element} option The option input to add the event listener to.
+ * @param {string} opt_parentName Optional name of the object inside of the
+ *    options object that the input element should add an attribute to.
+ */
+FactoryController.prototype.addOptionsListener = function (option,
+    opt_parentName) {
+  // Ensure only adding an event listener to a valid input element.
+  if (!option.name) {
     return;
   }
-  if (!confirm('Do you want to use the default workspace configuration ' +
-          'options for injecting a workspace with categories?')) {
-    return;
+  var name = option.name;
+  var id = option.id;
+  if (option.type == 'checkbox') {
+    // If adding an event listener for a checkbox.
+    option.addEventListener('change', function(optionName, optionId) {
+      return function() {
+        var checked = document.getElementById(optionId).checked;
+        controller.setOptionAndUpdate(optionName, checked, opt_parentName);
+      };
+    }(name, id));
+  } else {
+    // If adding an event listener for a text field (representing either a
+    // string or a number, as determined by the custom tag).
+    var type = option.getAttribute('custom');
+    option.addEventListener('change', function(optionName, optionId,
+        optionType) {
+      return function() {
+        var value = document.getElementById(optionId).value
+        if (optionType == 'number') {
+          value = parseInt(value);
+        }
+        controller.setOptionAndUpdate(optionName, value, opt_parentName);
+      };
+    }(name, id, type));
   }
-  this.model.setOption('collapse', true);
-  this.model.setOption('comments', true);
-  this.model.setOption('disable', true);
-  this.model.setOption('scrollbars', true);
-  this.model.setOption('trashcan', true);
-  this.reinjectPreview(Blockly.Options.parseToolboxTree
-        (this.generator.generateToolboxXml()));
-}
+};
 
 // Toolbox editing mode. Changes the user makes to the workspace updates the
 // toolbox.

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -483,13 +483,13 @@ FactoryController.prototype.loadCategory = function() {
     return;
   }
 
+  var firstCategory = !this.model.hasToolbox();
   // Copy the standard category in the model.
   var copy = standardCategory.copy();
   this.model.addElementToList(copy);
 
   // Update the copy in the view.
-  var tab = this.view.addCategoryRow(copy.name, copy.id,
-      this.model.getSelected() == null);
+  var tab = this.view.addCategoryRow(copy.name, copy.id, firstCategory);
   this.addClickToSwitch(tab, copy.id);
   // Color the category tab in the view.
   if (copy.color) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -29,13 +29,15 @@ FactoryGenerator = function(model) {
 /**
  * Generates the xml for the toolbox or flyout with information from
  * toolboxWorkspace and the model. Uses the hiddenWorkspace to generate XML.
+ * Save state of workspace in model (saveFromWorkspace) before calling if
+ * changes might have been made to the selected category.
  *
  * @param {!Blockly.workspace} toolboxWorkspace Toolbox editing workspace where
  * blocks are added by user to be part of the toolbox.
  * @return {!Element} XML element representing toolbox or flyout corresponding
  * to toolbox workspace.
  */
-FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
+FactoryGenerator.prototype.generateToolboxXml = function() {
   // Create DOM for XML.
   var xmlDom = goog.dom.createDom('xml',
       {
@@ -44,8 +46,7 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
       });
   if (!this.model.hasToolbox()) {
     // Toolbox has no categories. Use XML directly from workspace.
-    this.loadToHiddenWorkspaceAndSave_
-        (Blockly.Xml.workspaceToDom(toolboxWorkspace), xmlDom);
+    this.loadToHiddenWorkspaceAndSave_(this.model.getSelectedXml(), xmlDom);
   } else {
     // Toolbox has categories.
     // Assert that selected != null
@@ -53,8 +54,6 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
       throw new Error('Selected is null when the toolbox is empty.');
     }
 
-    // Capture any changes made by user before generating XML.
-    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
     var xml = this.model.getSelectedXml();
     var toolboxList = this.model.getToolboxList();
 
@@ -94,15 +93,19 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   * it includes XY and ID attributes). Uses a workspace and converts user
   * generated shadow blocks to actual shadow blocks.
   *
-  * @param {!Blockly.workspace} toolboxWorkspace The workspace to load XML
-  *     from.
   */
-  // UPDATE CoMMENTS
- FactoryGenerator.prototype.generateWorkspaceXml = function(rawXml) {
+ FactoryGenerator.prototype.generateWorkspaceXml = function() {
+  // Load workspace XML to hidden workspace with user-generated shadow blocks
+  // as actual shadow blocks.
   this.hiddenWorkspace.clear();
-  Blockly.Xml.domToWorkspace(rawXml, this.hiddenWorkspace);
+  Blockly.Xml.domToWorkspace(this.model.getPreloadXml(), this.hiddenWorkspace);
   this.setShadowBlocksInHiddenWorkspace_();
-  return Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
+
+  // Generate XML and set attributes.
+  var generatedXml = Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
+  generatedXml.setAttribute('id', 'preload_blocks');
+  generatedXml.setAttribute('style', 'display:none');
+  return generatedXml;
  }
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -89,6 +89,14 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   return xmlDom;
  };
 
+ /**
+  * Generates XML for the workspace (different from generateConfigXml in that
+  * it includes XY and ID attributes). Uses a workspace and converts user
+  * generated shadow blocks to actual shadow blocks.
+  *
+  * @param {!Blockly.workspace} toolboxWorkspace The workspace to load XML
+  *     from.
+  */
  FactoryGenerator.prototype.generateWorkspaceXml = function(toolboxWorkspace) {
   this.hiddenWorkspace.clear();
   Blockly.Xml.domToWorkspace(Blockly.Xml.workspaceToDom(toolboxWorkspace),

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -89,6 +89,14 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   return xmlDom;
  };
 
+ FactoryGenerator.prototype.generateWorkspaceXml = function(toolboxWorkspace) {
+  this.hiddenWorkspace.clear();
+  Blockly.Xml.domToWorkspace(Blockly.Xml.workspaceToDom(toolboxWorkspace),
+      this.hiddenWorkspace);
+  this.setShadowBlocksInHiddenWorkspace_();
+  return Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
+ }
+
 /**
  * Load the given XML to the hidden workspace, set any user-generated shadow
  * blocks to be actual shadow blocks, then append the XML from the workspace

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -97,10 +97,10 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   * @param {!Blockly.workspace} toolboxWorkspace The workspace to load XML
   *     from.
   */
- FactoryGenerator.prototype.generateWorkspaceXml = function(toolboxWorkspace) {
+  // UPDATE CoMMENTS
+ FactoryGenerator.prototype.generateWorkspaceXml = function(rawXml) {
   this.hiddenWorkspace.clear();
-  Blockly.Xml.domToWorkspace(Blockly.Xml.workspaceToDom(toolboxWorkspace),
-      this.hiddenWorkspace);
+  Blockly.Xml.domToWorkspace(rawXml, this.hiddenWorkspace);
   this.setShadowBlocksInHiddenWorkspace_();
   return Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
  }

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -19,8 +19,9 @@ FactoryModel = function() {
   this.toolboxList = [];
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // String name of current selected list element, null if no list elements.
-  this.selected = new ListElement(ListElement.TYPE_CATEGORY); // make type default? update categories
+  // Currently selected ListElement. In list if there are categories, not in
+  // list if there is only a single flyout.
+  this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
   // Boolean for if a Procedure category has been added.
@@ -28,9 +29,6 @@ FactoryModel = function() {
   // XML to be pre-loaded to workspace. Empty on default;
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
 };
-
-// String name of current selected list element, null if no list elements.
-FactoryModel.prototype.selected = null;
 
 /**
  * Given a name, determines if it is the name of a category already present.
@@ -320,14 +318,23 @@ FactoryModel.prototype.getShadowBlocksInWorkspace = function(workspaceBlocks) {
   return shadowsInWorkspace;
 };
 
+/**
+ * Saves XML as XML to be pre-loaded into the workspace.
+ *
+ * @param {!Element} xml The XML to be saved.
+ */
 FactoryModel.prototype.savePreloadXml = function(xml) {
   this.preloadXml = xml
 };
 
+/**
+ * Gets the XML to be pre-loaded into the workspace.
+ *
+ * @return {!Element} The XML for the workspace.
+ */
 FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
-}
-
+};
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -30,7 +30,6 @@ FactoryModel = function() {
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
   // Options object to be configured for Blockly inject call.
   this.options = new Object(null);
-  //this.options = goog.dom.createDom();
 };
 
 /**
@@ -353,23 +352,42 @@ FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
 };
 
+/**
+ * Adds an attribute to the options object with the name type and the value
+ * value.
+ *
+ * @param {!string} type The name of the attribute to give to the options
+ *    object.
+ * @param {Object} value The value of the attribute added to options.
+ */
 FactoryModel.prototype.setOption = function(type, value) {
   this.options[type] = value;
-  //this.options.setAttribute(type, value)
-  if (!type) {
-    console.log("UNDEF");
-  }
-  console.log(this.options);
 };
 
+/**
+ * Adds an attribute to an object within the options object. If an option with
+ * that name does not exist, create a new one.
+ *
+ * @param {!string} The name of the object within the options object to add
+ *    the attribute to.
+ * @param {!string} type The name of the attribute to add to the object within
+ *    options.
+ * @param {Object} value The value of the attribute to be added to the object
+ *    within options.
+ */
 FactoryModel.prototype.setSubOption = function(option, type, value) {
   if (!this.options[option]) {
-    console.log("new option: " + option);
     this.options[option] = new Object(null);
   }
   this.options[option][type] = value;
 };
 
+/**
+ * Removes an option within the options object.
+ *
+ * @param {!string} type the name of the attribute to be removed from the
+ *    options object.
+ */
 FactoryModel.prototype.removeOption = function(type) {
   delete this.options[type];
 }

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -29,7 +29,8 @@ FactoryModel = function() {
   // XML to be pre-loaded to workspace. Empty on default;
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
   // Options object to be configured for Blockly inject call.
-  this.options = Object.create(null);
+  this.options = new Object(null);
+  //this.options = goog.dom.createDom();
 };
 
 /**
@@ -352,13 +353,26 @@ FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
 };
 
-FactoryModel.prototype.setOptions = function(type, value) {
+FactoryModel.prototype.setOption = function(type, value) {
   this.options[type] = value;
+  //this.options.setAttribute(type, value)
   if (!type) {
     console.log("UNDEF");
   }
   console.log(this.options);
 };
+
+FactoryModel.prototype.setSubOption = function(option, type, value) {
+  if (!this.options[option]) {
+    console.log("new option: " + option);
+    this.options[option] = new Object(null);
+  }
+  this.options[option][type] = value;
+};
+
+FactoryModel.prototype.removeOption = function(type) {
+  delete this.options[type];
+}
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -109,6 +109,11 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
       false : this.hasProcedureCategory;
   // Remove element.
   this.toolboxList.splice(index, 1);
+  // If removing last element from toolbox list, create empty list element
+  // for single flyout.
+  if (this.toolboxList.length == 0) {
+    this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+  }
 };
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -20,11 +20,13 @@ FactoryModel = function() {
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
   // String name of current selected list element, null if no list elements.
-  this.selected = null;
+  this.selected = new ListElement(ListElement.TYPE_CATEGORY); // make type default? update categories
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
   // Boolean for if a Procedure category has been added.
   this.hasProcedureCategory = false;
+  // XML to be pre-loaded to workspace. Empty on default;
+  this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
 };
 
 // String name of current selected list element, null if no list elements.
@@ -317,6 +319,14 @@ FactoryModel.prototype.getShadowBlocksInWorkspace = function(workspaceBlocks) {
   }
   return shadowsInWorkspace;
 };
+
+FactoryModel.prototype.savePreloadXml = function(xml) {
+  this.preloadXml = xml
+};
+
+FactoryModel.prototype.getPreloadXml = function() {
+  return this.preloadXml;
+}
 
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -111,10 +111,19 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
   this.toolboxList.splice(index, 1);
   // If removing last element from toolbox list, create empty list element
   // for single flyout.
+
+};
+
+/**
+ * Sets selected to be an empty category not in toolbox list if toolbox list
+ * is empty. Should be called when removing the last element from toolbox list.
+ *
+ */
+FactoryModel.prototype.setDefaultSelected = function() {
   if (this.toolboxList.length == 0) {
     this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   }
-};
+}
 
 /**
  * Moves a list element to a certain position in toolboxList by removing it

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -28,6 +28,8 @@ FactoryModel = function() {
   this.hasProcedureCategory = false;
   // XML to be pre-loaded to workspace. Empty on default;
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
+  // Options object to be configured for Blockly inject call.
+  this.options = Object.create(null);
 };
 
 /**
@@ -348,6 +350,14 @@ FactoryModel.prototype.savePreloadXml = function(xml) {
  */
 FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
+};
+
+FactoryModel.prototype.setOptions = function(type, value) {
+  this.options[type] = value;
+  if (!type) {
+    console.log("UNDEF");
+  }
+  console.log(this.options);
 };
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -314,3 +314,21 @@ FactoryView.prototype.unmarkShadowBlock = function(block) {
     Blockly.removeClass_(block.svgGroup_, 'shadowBlock');
   }
 };
+
+/**
+ * Sets the tabs for modes according to which mode the user is currenly
+ * editing in.
+ *
+ * @param {!string} tab The type of tab being switched to
+ *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
+ */
+FactoryView.prototype.setModeSelection = function(mode) {
+  document.getElementById('tab_preload').className = mode ==
+      FactoryController.MODE_PRELOAD ? 'tabon' : 'taboff';
+  document.getElementById('preload_div').style.display = mode ==
+      FactoryController.MODE_PRELOAD ? 'block' : 'none';
+  document.getElementById('tab_toolbox').className = mode ==
+      FactoryController.MODE_TOOLBOX ? 'tabon' : 'taboff';
+  document.getElementById('toolbox_div').style.display = mode ==
+      FactoryController.MODE_TOOLBOX ? 'block' : 'none';
+};


### PR DESCRIPTION
Allows the user to configure the options object used to inject Blockly with checkboxes and text fields. Updates the preview workspace automatically to reflect changes to the options object. Uses the Blockly default values to start with and allows the user to revert to those with a button. On changing from a single flyout to categories or categories to a single flyout, asks the user if they would like to change the category-specific default option values. Allows the user to save the options object to a file. 

Files changed: index.html, style.css (very minor, small button), wfactory_controller.js, wfactory_model.js
![options no grid](https://cloud.githubusercontent.com/assets/18580768/17569834/c94a4e6c-5efe-11e6-9074-c0e9cf71627e.png)
![options with grid](https://cloud.githubusercontent.com/assets/18580768/17569832/c7807ef8-5efe-11e6-906b-886c60d2fb71.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/40)

<!-- Reviewable:end -->
