### PR TITLE
Workspace Factory #16: Configure Options Object

### DIFF
--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -671,6 +671,11 @@ goog.require('goog.ui.ColorPicker');
         }
       }
     }
+
+    // Convert actual shadow blocks added from the toolbox to user-generated shadow blocks.
+    if (e.type == Blockly.Events.CREATE) {
+      controller.convertShadowBlocks();
+    }
   });
 
 </script>

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -111,11 +111,12 @@ goog.require('goog.ui.ColorPicker');
 
   <aside id='preload_div' style='display:none'>
     <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
+    <button id="button_standardOptions">Standard Options</button>
     <form id="workspace_options">
-      <input type="checkbox" id="collapse_checkbox" name="collapse" checked>Collapsible Blocks<br>
-      <input type="checkbox" id="comments_checkbox" name="comments" checked>Comments for Blocks<br>
+      <input type="checkbox" id="collapse_checkbox" name="collapse">Collapsible Blocks<br>
+      <input type="checkbox" id="comments_checkbox" name="comments">Comments for Blocks<br>
       <input type="checkbox" id="css_checkbox" name="css" checked>Use Blockly CSS<br>
-      <input type="checkbox" id="disable_checkbox" name="disable" checked>Disabled Blocks<br>
+      <input type="checkbox" id="disable_checkbox" name="disable">Disabled Blocks<br>
       <input type="checkbox" id="grid_checkbox" name="grid" value="grid">Use Grid<br>
       <div id="grid_options" name="grid" style="display:none">
         Spacing <input type="text" id="grid_spacing_text" name="spacing" custom="number" value="0"><br>
@@ -127,9 +128,9 @@ goog.require('goog.ui.ColorPicker');
       Path to Blockly Media <input type="text" id="media_text" name="media" custom="text" value='https://blockly-demo.appspot.com/static/media/'><br>
       <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only<br>
       <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL<br>
-      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars" checked>Scrollbars<br>
+      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars">Scrollbars<br>
       <input type="checkbox" id="sounds_checkbox" name="sounds" checked>Sounds<br>
-      <input type="checkbox" id="trashcan_checkbox" name="trashcan" checked>Trashcan<br>
+      <input type="checkbox" id="trashcan_checkbox" name="trashcan">Trashcan<br>
       <input type="checkbox" id="zoom_checkbox" name="zoom">Zoom<br>
       <div id="zoom_options" name="zoom" style="display:none">
         <input type="checkbox" id="zoom_controls_checkbox" name="controls">Zoom Controls<br>
@@ -679,6 +680,9 @@ goog.require('goog.ui.ColorPicker');
     controller.exportXmlFile(FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
+  var standardOptionsWrapper = function() {
+    controller.setStandardOptiosn();
+  };
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -728,6 +732,8 @@ goog.require('goog.ui.ColorPicker');
       ('click', editToolboxWrapper);
   document.getElementById('tab_preload').addEventListener
       ('click', editPreloadWrapper);
+  document.getElementById('button_standardOptions').addEventListener
+      ('click', standardOptionsWrapper);
 
   // Use up and down arrow keys to move categories.
   // TODO(evd2014): When merge with next CL for editing preloaded blocks, make sure

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -616,10 +616,10 @@ goog.require('goog.ui.ColorPicker');
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var editToolboxWrapper = function() {
-    controller.setTab(FactoryController.TAB_TOOLBOX);
+    controller.setMode(FactoryController.MODE_TOOLBOX);
   }
   var editPreloadWrapper = function() {
-    controller.setTab(FactoryController.TAB_PRELOAD);
+    controller.setMode(FactoryController.MODE_PRELOAD);
   }
 
   document.getElementById('button_add').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -543,7 +543,7 @@ goog.require('goog.ui.ColorPicker');
     if (Blockly.selected) {
       // Can only edit blocks when a block is selected.
 
-      if (!controller.model.isShadowBlock(Blockly.selected.id) && Blockly.selected.getSurroundParent() != null) {
+      if (!controller.isUserGenShadowBlock(Blockly.selected.id) && Blockly.selected.getSurroundParent() != null) {
         // If a block is selected that could be a valid shadow block (not a shadow block,
         // has a surrounding parent), let the user make it a shadow block.
         // Use toggle instead of add so that the user can click the button again
@@ -652,7 +652,7 @@ goog.require('goog.ui.ColorPicker');
         document.getElementById('button_editShadow').disabled = false;
         Blockly.selected.setWarningText(null);
       } else {
-        if (selected != null && controller.model.isShadowBlock(selected.id)) {
+        if (selected != null && controller.isUserGenShadowBlock(selected.id)) {
 
         // Provide warning if shadow block is moved and is no longer a valid shadow block.
           Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -655,8 +655,8 @@ goog.require('goog.ui.ColorPicker');
         if (selected != null && controller.isUserGenShadowBlock(selected.id)) {
 
         // Provide warning if shadow block is moved and is no longer a valid shadow block.
-          // Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +
-          //     ' blocks to be displayed.');
+          Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +
+              ' blocks to be displayed.');
 
           // Give editing options so that the user can make an invalid shadow block
           // a normal block.

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -111,25 +111,25 @@ goog.require('goog.ui.ColorPicker');
 
   <aside id='preload_div' style='display:none'>
     <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
-    <button id="button_standardOptions">Standard Options</button>
+    <button class="small" id="button_standardOptions">Standard Options</button>
     <form id="workspace_options">
       <input type="checkbox" id="collapse_checkbox" name="collapse">Collapsible Blocks<br>
       <input type="checkbox" id="comments_checkbox" name="comments">Comments for Blocks<br>
-      <input type="checkbox" id="css_checkbox" name="css" checked>Use Blockly CSS<br>
+      <input type="checkbox" id="css_checkbox" name="css">Use Blockly CSS<br>
       <input type="checkbox" id="disable_checkbox" name="disable">Disabled Blocks<br>
-      <input type="checkbox" id="grid_checkbox" name="grid" value="grid">Use Grid<br>
+      <input type="checkbox" id="grid_checkbox" name="grid">Use Grid<br>
       <div id="grid_options" name="grid" style="display:none">
         Spacing <input type="text" id="grid_spacing_text" name="spacing" custom="number" value="0"><br>
         Length <input type="text" id="grid_length_text" name="length" custom="number"value="1"><br>
         Color <input type="text" id="grid_colour_text" name="colour" custom="text" value="#888"><br>
-        <input type="checkbox" value="grid_snap_checkbox" name="snap">Snap<br>
+        <input type="checkbox" id="grid_snap_checkbox" value="grid_snap_checkbox" name="snap">Snap<br>
       </div>
-      Max Blocks <input type="text" id="maxBlocksValue_text" name="maxBlocks" custom="number" value="Infinity"><br>
-      Path to Blockly Media <input type="text" id="media_text" name="media" custom="text" value='https://blockly-demo.appspot.com/static/media/'><br>
+      Max Blocks <input type="text" id="maxBlocks_text" name="maxBlocks" custom="number" value="Infinity"><br>
+      Path to Blockly Media <input type="text" id="media_text" name="media" custom="text"><br>
       <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only<br>
       <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL<br>
       <input type="checkbox" id="scrollbars_checkbox" name="scrollbars">Scrollbars<br>
-      <input type="checkbox" id="sounds_checkbox" name="sounds" checked>Sounds<br>
+      <input type="checkbox" id="sounds_checkbox" name="sounds">Sounds<br>
       <input type="checkbox" id="trashcan_checkbox" name="trashcan">Trashcan<br>
       <input type="checkbox" id="zoom_checkbox" name="zoom">Zoom<br>
       <div id="zoom_options" name="zoom" style="display:none">
@@ -678,10 +678,11 @@ goog.require('goog.ui.ColorPicker');
   var exportAllWrapper = function() {
     controller.exportXmlFile(FactoryController.MODE_TOOLBOX);
     controller.exportXmlFile(FactoryController.MODE_PRELOAD);
+    controller.exportOptionsFile();
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var standardOptionsWrapper = function() {
-    controller.setStandardOptiosn();
+    controller.setStandardOptionsAndUpdate();
   };
 
   document.getElementById('button_add').addEventListener
@@ -817,144 +818,50 @@ goog.require('goog.ui.ColorPicker');
     }
   });
 
-  //UNIFY
+  // Add event listeners for checkboxes and text fields for configuring the Options object.
+
+  // Checking the grid checkbox displays and applys grid options.
+  // Unchecking the grid checkbox removes the grid object from the options object and
+  // hides the grid options.
   document.getElementById('grid_checkbox').addEventListener('change', function(e) {
       document.getElementById('grid_options').style.display = document.getElementById('grid_checkbox').checked ? 'block' : 'none';
       if (!document.getElementById('grid_checkbox').checked) {
         controller.removeOption('grid');
       } else {
-        var options = document.getElementById('grid_options').children;
-        for (var i = 0, option; option = options[i]; i++) {
-          if (option.type == 'checkbox') {
-            controller.setOptions(option.name, option.checked, 'grid');
-          } else {
-            var value = option.value;
-            if (type = option.getAttribute('custom') == 'number') {
-              value = parseInt(value);
-            }
-            controller.setOptions(option.name, value, 'grid');
-          }
-        }
+        controller.openAndApplySubOptions('grid', document.getElementById('grid_options').children);
       }
   });
-  // MOVE TO METHOD IN CONTROLLER
+
+  // Checking the zoom checkbox displays and applys grid options.
+  // Unchecking the zoom checkbox removes the zoom object from the options object and
+  // hides the zoom options.
   document.getElementById('zoom_checkbox').addEventListener('change', function(e) {
       document.getElementById('zoom_options').style.display = document.getElementById('zoom_checkbox').checked ? 'block' : 'none';
       if (!document.getElementById('zoom_checkbox').checked) {
         controller.removeOption('zoom');
       } else {
-        var options = document.getElementById('zoom_options').children;
-        for (var i = 0, option; option = options[i]; i++) {
-          if (option.type == 'checkbox') {
-            controller.setOptions(option.name, option.checked, 'zoom');
-          } else {
-            var value = option.value;
-            if (type = option.getAttribute('custom') == 'number') {
-              value = parseInt(value);
-            }
-            controller.setOptions(option.name, value, 'zoom');
-          }
-        }
+        controller.openAndApplySubOptions('zoom', document.getElementById('zoom_options').children);
       }
   });
-  // document.getElementById('maxBlocks_checkbox').addEventListener('change', function(e) {
-  //     document.getElementById('maxBlocks_options').style.display = document.getElementById('maxBlocks_checkbox').checked ? 'none' : 'block';
-  // });
 
-  // document.getElementById('comments_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('comments', document.getElementById('comments_checkbox').checked);
-  // });
-  // document.getElementById('css_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('css', document.getElementById('css_checkbox').checked);
-  // });
-  // document.getElementById('disable_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('disable', document.getElementById('disable_checkbox').checked);
-  // });
-  // document.getElementById('readOnly_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('readOnly', document.getElementById('readOnly_checkbox').checked);
-  // });
-  // document.getElementById('rtl_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('rtl', document.getElementById('rtl_checkbox').checked);
-  // });
-  // document.getElementById('scrollbars_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('scrollbars', document.getElementById('scrollbars_checkbox').checked);
-  // });
-  // document.getElementById('sounds_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('sounds', document.getElementById('sounds_checkbox').checked);
-  // });
-  // document.getElementById('trashbox_checkbox').addEventListener('change', function(e) {
-  //     controller.setOptions('trashbox', document.getElementById('trashbox_checkbox').checked);
-  // });
-
+  // Add event listeners for all options checkboxes and text fields (not zoom and grid).
   var options = document.getElementById('workspace_options').children;
   for (var i = 0, option; option = options[i]; i++) {
-    console.log('ID: ' + option.id);
-    if (option.tagName != 'DIV' && option.name && option.name != 'grid' && option.name !='zoom') {
-      var name = option.name;
-      var id = option.id;
-      if (option.type == 'checkbox') {
-        controller.setOptions(option.name, option.checked);
-        option.addEventListener('change', function(optionName, optionId) {
-          return function() {
-            var checked = document.getElementById(optionId).checked;
-            console.log(checked + ' ' + optionName);
-            controller.setOptions(optionName, checked);
-          };
-        }(name, id));
-      } else {
-        controller.setOptions(option.name, option.value);
-        var type = option.getAttribute('custom');
-        option.addEventListener('change', function(optionName, optionId, optionType) {
-          return function() {
-            var value = document.getElementById(optionId).value
-            if (optionType == 'number') {
-              console.log("parsing");
-              value = parseInt(value);
-            }
-            console.log(value + ' ' + optionName);
-            controller.setOptions(optionName, value);
-          };
-        }(name, id, type));
-      }
+    if (option.name && option.getAttribute('name') != 'grid' && option.getAttribute('name') !='zoom') {
+      controller.addOptionsListener(option);
     } else if (option.id == 'grid_options' || option.id == 'zoom_options') {
+      // Add event listeners for suboptions of grid and zoom.
       var subOptions = option.children;
-      console.log(option.name);
-      console.log(subOptions.length);
       for (var j = 0, subOption; subOption = subOptions[j]; j++) {
         if (subOption.name) {
-          var subName = subOption.name;
-          var id = subOption.id;
-          var name = option.getAttribute('name');
-          console.log(name);
-          if (subOption.type == 'checkbox') {
-            // controller.setOptions(subOption.name, subOption.checked, name);
-            subOption.addEventListener('change', function(optionName, subOptionName, subOptionId) {
-              return function() {
-                var checked = document.getElementById(subOptionId).checked;
-                console.log(checked + ' ' + optionName + ' ' + subOptionName);
-                controller.setOptions(subOptionName, checked, optionName);
-              };
-            }(name, subName, id));
-          } else {
-            // controller.setOptions(subOption.name, subOption.value, name);
-            var type = subOption.getAttribute('custom');
-            subOption.addEventListener('change', function(optionName, subOptionName, subOptionId, subOptionType) {
-              return function() {
-                var value = document.getElementById(subOptionId).value
-                if (subOptionType == 'number') {
-                  console.log("parsing");
-                  value = parseInt(value);
-                }
-                console.log(value + ' ' + subOptionName);
-                controller.setOptions(subOptionName, value, optionName);
-              };
-            }(name, subName, id, type));
-          }
+          controller.addOptionsListener(subOption, option.getAttribute('name'));
         }
       }
-      console.log('done with iteration of for loop');
     }
   }
+
+  // Check standard options and apply the changes to update the view.
+  controller.setStandardOptionsAndUpdate();
 
 </script>
 </html>

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -615,6 +615,12 @@ goog.require('goog.ui.ColorPicker');
     controller.exportFile(FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
+  var editToolboxWrapper = function() {
+    controller.setTab(FactoryController.TAB_TOOLBOX);
+  }
+  var editPreloadWrapper = function() {
+    controller.setTab(FactoryController.TAB_PRELOAD);
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -532,21 +532,26 @@ goog.require('goog.ui.ColorPicker');
     var shadowRemoveWrapper = function() {
     controller.removeShadow();
     document.getElementById('dropdown_editShadowRemove').classList.remove("show");
+    // If turning invalid shadow block back to normal block, remove warning and disable
+    // block editing privileges.
+    Blockly.selected.setWarningText(null);
+    if (!Blockly.selected.getSurroundParent()) {
+      document.getElementById('button_editShadow').disabled = true;
+    }
   };
   var editShadowWrapper = function() {
-    // Allow the user to make a block a shadow block only if a block is selected
-    // and the block has a surrounding parent (necessary for the block to be
-    // a valid shadow block).
-    if (Blockly.selected && Blockly.selected.getSurroundParent() != null) {
-      // If the block is not a shadow block, let the user make it a shadow block.
-      // Use toggle instead of add so that the user can click the button again
-      // to make the dropdown disappear without clicking one of the options.
-      if (!controller.model.isShadowBlock(Blockly.selected.id)) {
+    if (Blockly.selected) {
+      // Can only edit blocks when a block is selected.
 
+      if (!controller.model.isShadowBlock(Blockly.selected.id) && Blockly.selected.getSurroundParent() != null) {
+        // If a block is selected that could be a valid shadow block (not a shadow block,
+        // has a surrounding parent), let the user make it a shadow block.
+        // Use toggle instead of add so that the user can click the button again
+        // to make the dropdown disappear without clicking one of the options.
         document.getElementById('dropdown_editShadowRemove').classList.remove("show");
         document.getElementById('dropdown_editShadowAdd').classList.toggle("show");
-      // If the block is a shadow block, let the user make it a normal block.
       } else {
+        // If the block is a shadow block, let the user make it a normal block.
         document.getElementById('dropdown_editShadowAdd').classList.remove("show");
         document.getElementById('dropdown_editShadowRemove').classList.toggle("show");
       }
@@ -621,21 +626,38 @@ goog.require('goog.ui.ColorPicker');
     if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
       controller.updatePreview();
     }
+
     // Listen for Blockly UI events to correctly enable the "Edit Block" button.
     // Only enable "Edit Block" when a block is selected and it has a surrounding
     // parent, meaning it is nested in another block (blocks that are not
     // nested in parents cannot be shadow blocks).
-    // TODO(evd2014): Listen for when the user has moved a block to be nested inside
-    // another (currently have to unselect and reselect that block).
     if (e.type == Blockly.Events.MOVE || (e.type == Blockly.Events.UI &&
         e.element == 'selected')) {
-      var selected = toolboxWorkspace.getBlockById(e.newValue);
+      var selected = Blockly.selected;
+
       if (selected != null && selected.getSurroundParent() != null) {
+
+        // A valid shadow block is selected. Enable block editing and remove warnings.
         document.getElementById('button_editShadow').disabled = false;
+        Blockly.selected.setWarningText(null);
       } else {
-        document.getElementById('button_editShadow').disabled = true;
-        document.getElementById('dropdown_editShadowRemove').classList.remove("show");
-        document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+        if (selected != null && controller.model.isShadowBlock(selected.id)) {
+
+        // Provide warning if shadow block is moved and is no longer a valid shadow block.
+          Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +
+              ' blocks to be displayed.');
+
+          // Give editing options so that the user can make an invalid shadow block
+          // a normal block.
+          document.getElementById('button_editShadow').disabled = false;
+        } else {
+
+          // No block selected that is a shadow block or could be a valid shadow block.
+          // Disable block editing.
+          document.getElementById('button_editShadow').disabled = true;
+          document.getElementById('dropdown_editShadowRemove').classList.remove("show");
+          document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+        }
       }
     }
   });

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -655,8 +655,8 @@ goog.require('goog.ui.ColorPicker');
         if (selected != null && controller.isUserGenShadowBlock(selected.id)) {
 
         // Provide warning if shadow block is moved and is no longer a valid shadow block.
-          Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +
-              ' blocks to be displayed.');
+          // Blockly.selected.setWarningText('Shadow blocks must be nested inside other' +
+          //     ' blocks to be displayed.');
 
           // Give editing options so that the user can make an invalid shadow block
           // a normal block.

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -50,7 +50,7 @@ goog.require('goog.ui.ColorPicker');
         </div>
 
         <button id="button_print">Print Toolbox</button>
-        <button id="button_clear">Clear</button>
+        <button id="button_clear">Clear Toolbox</button>
       </p>
     </td>
   </tr>
@@ -586,7 +586,7 @@ goog.require('goog.ui.ColorPicker');
     document.getElementById('dropdownDiv_export').classList.remove("show");
   };
   var clearWrapper = function() {
-    controller.clear();
+    controller.clearToolbox();
   };
   var editToolboxWrapper = function() {
     controller.setMode(FactoryController.MODE_TOOLBOX);

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -581,7 +581,6 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
-<<<<<<< 8d894a801cfe834cbaa1a468d1430524e90e4527
   var importWrapper = function() {
     document.getElementById('dropdownDiv_import').classList.toggle("show");
     document.getElementById('dropdownDiv_export').classList.remove("show");
@@ -627,9 +626,22 @@ goog.require('goog.ui.ColorPicker');
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var importPreloadWrapper = function(e) {
-    controller.importFile(event.target.files[0]), false;
+    controller.importFile(event.target.files[0], FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
+  var exportToolboxWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportPreloadWrapper = function() {
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportAllWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -113,32 +113,32 @@ goog.require('goog.ui.ColorPicker');
     <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
     <button class="small" id="button_standardOptions">Standard Options</button>
     <form id="workspace_options">
-      <input type="checkbox" id="collapse_checkbox" name="collapse">Collapsible Blocks<br>
-      <input type="checkbox" id="comments_checkbox" name="comments">Comments for Blocks<br>
-      <input type="checkbox" id="css_checkbox" name="css">Use Blockly CSS<br>
-      <input type="checkbox" id="disable_checkbox" name="disable">Disabled Blocks<br>
-      <input type="checkbox" id="grid_checkbox" name="grid">Use Grid<br>
+      <input type="checkbox" id="option_collapse_checkbox" name="collapse">Collapsible Blocks<br>
+      <input type="checkbox" id="option_comments_checkbox" name="comments">Comments for Blocks<br>
+      <input type="checkbox" id="option_css_checkbox" name="css">Use Blockly CSS<br>
+      <input type="checkbox" id="option_disable_checkbox" name="disable">Disabled Blocks<br>
+      <input type="checkbox" id="option_grid_checkbox" name="grid">Use Grid<br>
       <div id="grid_options" name="grid" style="display:none">
-        Spacing <input type="text" id="grid_spacing_text" name="spacing" custom="number" value="0"><br>
-        Length <input type="text" id="grid_length_text" name="length" custom="number"value="1"><br>
-        Color <input type="text" id="grid_colour_text" name="colour" custom="text" value="#888"><br>
-        <input type="checkbox" id="grid_snap_checkbox" value="grid_snap_checkbox" name="snap">Snap<br>
+        Spacing <input type="text" id="gridOption_spacing_text" name="spacing" custom="number" value="0"><br>
+        Length <input type="text" id="gridOption_length_text" name="length" custom="number"value="1"><br>
+        Color <input type="text" id="gridOption_colour_text" name="colour" custom="text" value="#888"><br>
+        <input type="checkbox" id="gridOption_snap_checkbox" value="grid_snap_checkbox" name="snap">Snap<br>
       </div>
-      Max Blocks <input type="text" id="maxBlocks_text" name="maxBlocks" custom="number" value="Infinity"><br>
-      Path to Blockly Media <input type="text" id="media_text" name="media" custom="text"><br>
-      <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only<br>
-      <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL<br>
-      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars">Scrollbars<br>
-      <input type="checkbox" id="sounds_checkbox" name="sounds">Sounds<br>
-      <input type="checkbox" id="trashcan_checkbox" name="trashcan">Trashcan<br>
-      <input type="checkbox" id="zoom_checkbox" name="zoom">Zoom<br>
+      Max Blocks <input type="text" id="option_maxBlocks_text" name="maxBlocks" custom="number" value="Infinity"><br>
+      Path to Blockly Media <input type="text" id="option_media_text" name="media" custom="text"><br>
+      <input type="checkbox" id="option_readOnly_checkbox" name="readOnly">Read Only<br>
+      <input type="checkbox" id="option_rtl_checkbox" name="rtl">Layout with RTL<br>
+      <input type="checkbox" id="option_scrollbars_checkbox" name="scrollbars">Scrollbars<br>
+      <input type="checkbox" id="option_sounds_checkbox" name="sounds">Sounds<br>
+      <input type="checkbox" id="option_trashcan_checkbox" name="trashcan">Trashcan<br>
+      <input type="checkbox" id="option_zoom_checkbox" name="zoom">Zoom<br>
       <div id="zoom_options" name="zoom" style="display:none">
-        <input type="checkbox" id="zoom_controls_checkbox" name="controls">Zoom Controls<br>
-        <input type="checkbox" id="zoom_wheel_checkbox" name="wheel">Zoom Wheel<br>
-        Start Scale <input type="text" id="zoom_startScale_text" name="startScale" custom="number" value="1.0"><br>
-        Max Scale <input type="text" id="zoom_maxScale_text" name="maxScale" custom="number" value="3"><br>
-        Min Scale <input type="text" id="zoom_minScale_text" name="minScale" custom="number" value="0.3"><br>
-        Scale Speed <input type="text" id="zoom_scaleSpeed_text" name="scaleSpeed" custom="number" value="1.2"><br>
+        <input type="checkbox" id="zoomOption_controls_checkbox" name="controls">Zoom Controls<br>
+        <input type="checkbox" id="zoomOption_wheel_checkbox" name="wheel">Zoom Wheel<br>
+        Start Scale <input type="text" id="zoomOption_startScale_text" name="startScale" custom="number" value="1.0"><br>
+        Max Scale <input type="text" id="zoomOption_maxScale_text" name="maxScale" custom="number" value="3"><br>
+        Min Scale <input type="text" id="zoomOption_minScale_text" name="minScale" custom="number" value="0.3"><br>
+        Scale Speed <input type="text" id="zoomOption_scaleSpeed_text" name="scaleSpeed" custom="number" value="1.2"><br>
       </div>
     </form>
   </aside>
@@ -820,41 +820,37 @@ goog.require('goog.ui.ColorPicker');
 
   // Add event listeners for checkboxes and text fields for configuring the Options object.
 
-  // Checking the grid checkbox displays and applys grid options.
-  // Unchecking the grid checkbox removes the grid object from the options object and
-  // hides the grid options.
-  document.getElementById('grid_checkbox').addEventListener('change', function(e) {
-      document.getElementById('grid_options').style.display = document.getElementById('grid_checkbox').checked ? 'block' : 'none';
-      if (!document.getElementById('grid_checkbox').checked) {
-        controller.removeOption('grid');
-      } else {
-        controller.applySubOptions('grid', document.getElementById('grid_options').children);
-      }
+  // Checking the grid checkbox displays grid options and updates the options
+  // object.
+  document.getElementById('option_grid_checkbox').addEventListener('change', function(e) {
+      document.getElementById('grid_options').style.display = document.getElementById('option_grid_checkbox').checked ? 'block' : 'none';
+      controller.generateNewOptions();
   });
 
-  // Checking the zoom checkbox displays and applys grid options.
-  // Unchecking the zoom checkbox removes the zoom object from the options object and
-  // hides the zoom options.
-  document.getElementById('zoom_checkbox').addEventListener('change', function(e) {
-      document.getElementById('zoom_options').style.display = document.getElementById('zoom_checkbox').checked ? 'block' : 'none';
-      if (!document.getElementById('zoom_checkbox').checked) {
-        controller.removeOption('zoom');
-      } else {
-        controller.applySubOptions('zoom', document.getElementById('zoom_options').children);
-      }
+  // Checking the grid checkbox displays zoom options and updates the options
+  // object.
+  document.getElementById('option_zoom_checkbox').addEventListener('change', function(e) {
+      document.getElementById('zoom_options').style.display = document.getElementById('option_zoom_checkbox').checked ? 'block' : 'none';
+      controller.generateNewOptions();
   });
 
   // Add event listeners for all options checkboxes and text fields (not zoom and grid).
   var options = document.getElementById('workspace_options').children;
   for (var i = 0, option; option = options[i]; i++) {
+
     if (option.name && option.getAttribute('name') != 'grid' && option.getAttribute('name') !='zoom') {
-      controller.addOptionsListener(option);
+      option.addEventListener('change', function() {
+        controller.generateNewOptions();
+      });
+
     } else if (option.id == 'grid_options' || option.id == 'zoom_options') {
       // Add event listeners for suboptions of grid and zoom.
-      var subOptions = option.children;
-      for (var j = 0, subOption; subOption = subOptions[j]; j++) {
+
+      for (var j = 0, subOption; subOption = option.children[j]; j++) {
         if (subOption.name) {
-          controller.addOptionsListener(subOption, option.getAttribute('name'));
+          option.addEventListener('change', function() {
+            controller.generateNewOptions();
+          });
         }
       }
     }

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -45,6 +45,7 @@ goog.require('goog.ui.ColorPicker');
         <div id="dropdownDiv_export" class="dropdown-content">
           <a id='dropdown_exportToolbox'>Toolbox</a>
           <a id='dropdown_exportPreload'>Workspace Blocks</a>
+          <a id='dropdown_exportOptions'>Inject Options</a>
           <a id='dropdown_exportAll'>All</a>
         </div>
         </div>
@@ -666,12 +667,16 @@ goog.require('goog.ui.ColorPicker');
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var exportPreloadWrapper = function() {
-    controller.exportFile(FactoryController.MODE_PRELOAD);
+    controller.exportXmlFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportOptionsWrapper = function() {
+    controller.exportOptionsFile();
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
   var exportAllWrapper = function() {
-    controller.exportFile(FactoryController.MODE_TOOLBOX);
-    controller.exportFile(FactoryController.MODE_PRELOAD);
+    controller.exportXmlFile(FactoryController.MODE_TOOLBOX);
+    controller.exportXmlFile(FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_export').classList.remove("show");
   }
 
@@ -689,6 +694,8 @@ goog.require('goog.ui.ColorPicker');
       ('click', exportToolboxWrapper);
   document.getElementById('dropdown_exportPreload').addEventListener
       ('click', exportPreloadWrapper);
+  document.getElementById('dropdown_exportOptions').addEventListener
+      ('click', exportOptionsWrapper);
   document.getElementById('dropdown_exportAll').addEventListener
       ('click', exportAllWrapper);
   document.getElementById('button_export').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -111,35 +111,35 @@ goog.require('goog.ui.ColorPicker');
   <aside id='preload_div' style='display:none'>
     <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
     <form id="workspace_options">
-      <input type="checkbox" id="collapse_checkbox" checked>Collapsible Blocks<br>
-      <input type="checkbox" id="comments_checkbox" checked>Comments for Blocks<br>
-      <input type="checkbox" id="css_checkbox" checked>Use Blockly CSS<br>
-      <input type="checkbox" id="disable_checkbox" checked>Disabled Blocks<br>
-      <input type="checkbox" id="grid_checkbox" value="grid">Use Grid<br>
+      <input type="checkbox" id="collapse_checkbox" name="collapse" checked>Collapsible Blocks
+      <input type="checkbox" id="comments_checkbox" name="comments" checked>Comments for Blocks
+      <input type="checkbox" id="css_checkbox" name="css" checked>Use Blockly CSS
+      <input type="checkbox" id="disable_checkbox" name="disable" checked>Disabled Blocks
+      <input type="checkbox" id="grid_checkbox" name="grid" value="grid">Use Grid
       <div id="grid_options" style="display:none">
-        Spacing <input type="text" id="grid_spacing_text" value="0"><br>
-        Length <input type="text" id="grid_length_text" value="1"><br>
-        Color <input type="text" id="grid_colour_text" value="'#888'"><br>
-        <input type="checkbox" value="grid_snap_checkbox">Snap<br>
+        Spacing <input type="text" id="grid_spacing_text" name="spacing" value="0">
+        Length <input type="text" id="grid_length_text" name="length" value="1">
+        Color <input type="text" id="grid_colour_text" name="colour" value="'#888'">
+        <input type="checkbox" value="grid_snap_checkbox" name="snap">Snap
       </div>
-      <input type="checkbox" id="maxBlocks_checkbox" checked>Infinite Number of Blocks<br>
+      <input type="checkbox" id="maxBlocks_checkbox" name="maxBlocks" checked>Infinite Number of Blocks
       <div id="maxBlocks_options" style="display:none">
-        Max Blocks <input type="text" id="maxBlocksValue_text" value="0"><br>
+        Max Blocks <input type="text" id="maxBlocksValue_text" name="maxBlocks" value="0">
       </div>
-      Path to Blockly Media <input type="text" id="media_text" value='"https://blockly-demo.appspot.com/static/media/"'><br>
-      <input type="checkbox" id="readOnly_checkbox">Read Only<br>
-      <input type="checkbox" id="rtl_checkbox">Layout with RTL<br>
-      <input type="checkbox" id="scrollbars_checkbox" checked>Scrollbars<br>
-      <input type="checkbox" id="sounds_checkbox" checked>Sounds<br>
-      <input type="checkbox" id="trashbox_checkbox" checked>Trashcan<br>
-      <input type="checkbox" id="zoom_checkbox" value="zoom">Zoom<br>
+      Path to Blockly Media <input type="text" id="media_text" name="media" value='https://blockly-demo.appspot.com/static/media/'>
+      <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only
+      <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL
+      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars" checked>Scrollbars
+      <input type="checkbox" id="sounds_checkbox" name="sounds" checked>Sounds
+      <input type="checkbox" id="trashbox_checkbox" name="trashbox" checked>Trashcan
+      <input type="checkbox" id="zoom_checkbox" name="zoom" value="zoom">Zoom
       <div id="zoom_options" style="display:none">
-        <input type="checkbox" id="zoom_controls_checkbox">Zoom Controls<br>
-        <input type="checkbox" id="zoom_wheel_checkbox">Zoom Wheel<br>
-        Start Scale <input type="text" id="zoom_startScale_text" value="1.0"><br>
-        Max Scale <input type="text" id="zoom_maxScale_text" value="3"><br>
-        Min Scale <input type="text" id="zoom_minScale_text" value="0.3"><br>
-        Scale Speed <input type="text" id="zoom_scaleSpeed_text" value="1.2"><br>
+        <input type="checkbox" id="zoom_controls_checkbox" name="controls">Zoom Controls
+        <input type="checkbox" id="zoom_wheel_checkbox" name="wheel">Zoom Wheel
+        Start Scale <input type="text" id="zoom_startScale_text" name="startScale" value="1.0">
+        Max Scale <input type="text" id="zoom_maxScale_text" name="maxScale" value="3">
+        Min Scale <input type="text" id="zoom_minScale_text" name="minScale" value="0.3">
+        Scale Speed <input type="text" id="zoom_scaleSpeed_text" name="scaleSpeed" value="1.2">
       </div>
     </form>
   </aside>
@@ -816,7 +816,50 @@ goog.require('goog.ui.ColorPicker');
   document.getElementById('maxBlocks_checkbox').addEventListener('change', function(e) {
       document.getElementById('maxBlocks_options').style.display = document.getElementById('maxBlocks_checkbox').checked ? 'none' : 'block';
   });
-  //document.getElementById('zoom_checkbox').addEventListener('change',
+
+  document.getElementById('comments_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('comments', document.getElementById('comments_checkbox').checked);
+  });
+  document.getElementById('css_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('css', document.getElementById('css_checkbox').checked);
+  });
+  document.getElementById('disable_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('disable', document.getElementById('disable_checkbox').checked);
+  });
+  document.getElementById('readOnly_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('readOnly', document.getElementById('readOnly_checkbox').checked);
+  });
+  document.getElementById('rtl_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('rtl', document.getElementById('rtl_checkbox').checked);
+  });
+  document.getElementById('scrollbars_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('scrollbars', document.getElementById('scrollbars_checkbox').checked);
+  });
+  document.getElementById('sounds_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('sounds', document.getElementById('sounds_checkbox').checked);
+  });
+  document.getElementById('trashbox_checkbox').addEventListener('change', function(e) {
+      controller.setOptions('trashbox', document.getElementById('trashbox_checkbox').checked);
+  });
+
+  var options = document.getElementById('workspace_options').children;
+  for (var i = 0, option; option = options[i]; i++) {
+    if (option.tagName != 'div' && option.name) {
+      if (option.type == 'checkbox') {
+        controller.setOptions(option.name, option.checked);
+        option.addEventListener('change', function(option, controller) {
+          return function() {
+            controller.setOptions(option.name, option.checked);
+          };
+        }());
+      } else {
+        controller.setOptions(option.name, option.value);
+        option.addEventListener('change', function(e) {
+          controller.setOptions(option.name, option.checked);
+        });
+      }
+    }
+  }
 
 </script>
 </html>

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -119,13 +119,13 @@ goog.require('goog.ui.ColorPicker');
       <input type="checkbox" id="option_disable_checkbox" name="disable">Disabled Blocks<br>
       <input type="checkbox" id="option_grid_checkbox" name="grid">Use Grid<br>
       <div id="grid_options" name="grid" style="display:none">
-        Spacing <input type="text" id="gridOption_spacing_text" name="spacing" custom="number" value="0"><br>
-        Length <input type="text" id="gridOption_length_text" name="length" custom="number"value="1"><br>
-        Color <input type="text" id="gridOption_colour_text" name="colour" custom="text" value="#888"><br>
+        Spacing <input type="text" id="gridOption_spacing_text" name="spacing" value="0"><br>
+        Length <input type="text" id="gridOption_length_text" name="length" value="1"><br>
+        Color <input type="text" id="gridOption_colour_text" name="colour" value="#888"><br>
         <input type="checkbox" id="gridOption_snap_checkbox" value="grid_snap_checkbox" name="snap">Snap<br>
       </div>
-      Max Blocks <input type="text" id="option_maxBlocks_text" name="maxBlocks" custom="number" value="Infinity"><br>
-      Path to Blockly Media <input type="text" id="option_media_text" name="media" custom="text"><br>
+      Max Blocks <input type="text" id="option_maxBlocks_text" name="maxBlocks" value="Infinity"><br>
+      Path to Blockly Media <input type="text" id="option_media_text" name="media"><br>
       <input type="checkbox" id="option_readOnly_checkbox" name="readOnly">Read Only<br>
       <input type="checkbox" id="option_rtl_checkbox" name="rtl">Layout with RTL<br>
       <input type="checkbox" id="option_scrollbars_checkbox" name="scrollbars">Scrollbars<br>
@@ -135,10 +135,10 @@ goog.require('goog.ui.ColorPicker');
       <div id="zoom_options" name="zoom" style="display:none">
         <input type="checkbox" id="zoomOption_controls_checkbox" name="controls">Zoom Controls<br>
         <input type="checkbox" id="zoomOption_wheel_checkbox" name="wheel">Zoom Wheel<br>
-        Start Scale <input type="text" id="zoomOption_startScale_text" name="startScale" custom="number" value="1.0"><br>
-        Max Scale <input type="text" id="zoomOption_maxScale_text" name="maxScale" custom="number" value="3"><br>
-        Min Scale <input type="text" id="zoomOption_minScale_text" name="minScale" custom="number" value="0.3"><br>
-        Scale Speed <input type="text" id="zoomOption_scaleSpeed_text" name="scaleSpeed" custom="number" value="1.2"><br>
+        Start Scale <input type="text" id="zoomOption_startScale_text" name="startScale" value="1.0"><br>
+        Max Scale <input type="text" id="zoomOption_maxScale_text" name="maxScale" value="3"><br>
+        Min Scale <input type="text" id="zoomOption_minScale_text" name="minScale" value="0.3"><br>
+        Scale Speed <input type="text" id="zoomOption_scaleSpeed_text" name="scaleSpeed" value="1.2"><br>
       </div>
     </form>
   </aside>
@@ -834,27 +834,32 @@ goog.require('goog.ui.ColorPicker');
       controller.generateNewOptions();
   });
 
-  // Add event listeners for all options checkboxes and text fields (not zoom and grid).
-  var options = document.getElementById('workspace_options').children;
-  for (var i = 0, option; option = options[i]; i++) {
+  var optionListener = function() {
+    controller.generateNewOptions();
+  };
 
-    if (option.name && option.getAttribute('name') != 'grid' && option.getAttribute('name') !='zoom') {
-      option.addEventListener('change', function() {
-        controller.generateNewOptions();
-      });
-
-    } else if (option.id == 'grid_options' || option.id == 'zoom_options') {
-      // Add event listeners for suboptions of grid and zoom.
-
-      for (var j = 0, subOption; subOption = option.children[j]; j++) {
-        if (subOption.name) {
-          option.addEventListener('change', function() {
-            controller.generateNewOptions();
-          });
-        }
-      }
-    }
-  }
+  // Add event listeners to generate new options for each options input field.
+  document.getElementById('option_collapse_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_comments_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_css_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_disable_checkbox').addEventListener('change', optionListener);
+  document.getElementById('gridOption_spacing_text').addEventListener('change', optionListener);
+  document.getElementById('gridOption_length_text').addEventListener('change', optionListener);
+  document.getElementById('gridOption_colour_text').addEventListener('change', optionListener);
+  document.getElementById('gridOption_snap_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_maxBlocks_text').addEventListener('change', optionListener);
+  document.getElementById('option_media_text').addEventListener('change', optionListener);
+  document.getElementById('option_readOnly_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_rtl_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_scrollbars_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_sounds_checkbox').addEventListener('change', optionListener);
+  document.getElementById('option_trashcan_checkbox').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_controls_checkbox').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_wheel_checkbox').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_startScale_text').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_maxScale_text').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_minScale_text').addEventListener('change', optionListener);
+  document.getElementById('zoomOption_scaleSpeed_text').addEventListener('change', optionListener);
 
   // Check standard options and apply the changes to update the view.
   controller.setStandardOptionsAndUpdate();

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -60,12 +60,13 @@ goog.require('goog.ui.ColorPicker');
   <p id="editHelpText">Drag blocks into your toolbox:</p>
   <table id='workspaceTabs'>
     <td id="tab_toolbox" class="tabon">Toolbox</td>
-    <td id="tab_preload" class="taboff">Pre-loaded Workspace</td>
+    <td id="tab_preload" class="taboff">Workspace</td>
   </table>
   <section id="toolbox_section">
     <div id="toolbox_blocks" class="content"></div>
     <div id='disable_div'></div>
   </section>
+
   <aside id="toolbox_div">
     <table id="categoryTable">
       <td id="tab_help">Your categories will appear here</td>
@@ -96,8 +97,6 @@ goog.require('goog.ui.ColorPicker');
     </div>
 
   </aside>
-  <aside id='preload_div' style='display:none'>
-  </aside>
 
   <div class='dropdown'>
     <button id="button_editShadow">Edit Block</button>
@@ -108,6 +107,42 @@ goog.require('goog.ui.ColorPicker');
       <a id='dropdown_removeShadow'>Remove Shadow</a>
     </div>
   </div>
+
+  <aside id='preload_div' style='display:none'>
+    <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
+    <form id="workspace_options">
+      <input type="checkbox" id="collapse_checkbox" checked>Collapsible Blocks<br>
+      <input type="checkbox" id="comments_checkbox" checked>Comments for Blocks<br>
+      <input type="checkbox" id="css_checkbox" checked>Use Blockly CSS<br>
+      <input type="checkbox" id="disable_checkbox" checked>Disabled Blocks<br>
+      <input type="checkbox" id="grid_checkbox" value="grid">Use Grid<br>
+      <div id="grid_options" style="display:none">
+        Spacing <input type="text" id="grid_spacing_text" value="0"><br>
+        Length <input type="text" id="grid_length_text" value="1"><br>
+        Color <input type="text" id="grid_colour_text" value="'#888'"><br>
+        <input type="checkbox" value="grid_snap_checkbox">Snap<br>
+      </div>
+      <input type="checkbox" id="maxBlocks_checkbox" checked>Infinite Number of Blocks<br>
+      <div id="maxBlocks_options" style="display:none">
+        Max Blocks <input type="text" id="maxBlocksValue_text" value="0"><br>
+      </div>
+      Path to Blockly Media <input type="text" id="media_text" value='"https://blockly-demo.appspot.com/static/media/"'><br>
+      <input type="checkbox" id="readOnly_checkbox">Read Only<br>
+      <input type="checkbox" id="rtl_checkbox">Layout with RTL<br>
+      <input type="checkbox" id="scrollbars_checkbox" checked>Scrollbars<br>
+      <input type="checkbox" id="sounds_checkbox" checked>Sounds<br>
+      <input type="checkbox" id="trashbox_checkbox" checked>Trashcan<br>
+      <input type="checkbox" id="zoom_checkbox" value="zoom">Zoom<br>
+      <div id="zoom_options" style="display:none">
+        <input type="checkbox" id="zoom_controls_checkbox">Zoom Controls<br>
+        <input type="checkbox" id="zoom_wheel_checkbox">Zoom Wheel<br>
+        Start Scale <input type="text" id="zoom_startScale_text" value="1.0"><br>
+        Max Scale <input type="text" id="zoom_maxScale_text" value="3"><br>
+        Min Scale <input type="text" id="zoom_minScale_text" value="0.3"><br>
+        Scale Speed <input type="text" id="zoom_scaleSpeed_text" value="1.2"><br>
+      </div>
+    </form>
+  </aside>
 
 </section>
 
@@ -771,6 +806,17 @@ goog.require('goog.ui.ColorPicker');
       controller.convertShadowBlocks();
     }
   });
+
+  document.getElementById('grid_checkbox').addEventListener('change', function(e) {
+      document.getElementById('grid_options').style.display = document.getElementById('grid_checkbox').checked ? 'block' : 'none';
+  });
+  document.getElementById('zoom_checkbox').addEventListener('change', function(e) {
+      document.getElementById('zoom_options').style.display = document.getElementById('zoom_checkbox').checked ? 'block' : 'none';
+  });
+  document.getElementById('maxBlocks_checkbox').addEventListener('change', function(e) {
+      document.getElementById('maxBlocks_options').style.display = document.getElementById('maxBlocks_checkbox').checked ? 'none' : 'block';
+  });
+  //document.getElementById('zoom_checkbox').addEventListener('change',
 
 </script>
 </html>

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -531,7 +531,7 @@ goog.require('goog.ui.ColorPicker');
   };
   var exportWrapper = function() {
     document.getElementById('dropdownDiv_export').classList.toggle("show");
-    //controller.exportConfig();
+    document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var printWrapper = function() {
     controller.printConfig();
@@ -581,9 +581,9 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
-  var importWrapper = function() {  // took an event e before, need to have listener with 'change' for files
+  var importWrapper = function() {
     document.getElementById('dropdownDiv_import').classList.toggle("show");
-    //controller.importFile(event.target.files[0]);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
   };
   var clearWrapper = function() {
     controller.clear();
@@ -595,13 +595,26 @@ goog.require('goog.ui.ColorPicker');
     controller.setMode(FactoryController.MODE_PRELOAD);
   };
   var importToolboxWrapper = function(e) {
-    controller.importFile(event.target.files[0], true);
+    controller.importFile(event.target.files[0], FactoryController.MODE_TOOLBOX);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var importPreloadWrapper = function(e) {
-    controller.importFile(event.target.files[0]), false;
+    controller.importFile(event.target.files[0], FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
+  var exportToolboxWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportPreloadWrapper = function() {
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportAllWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -613,6 +626,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', separatorWrapper);
   document.getElementById('button_remove').addEventListener
       ('click', removeWrapper);
+  document.getElementById('dropdown_exportToolbox').addEventListener
+      ('click', exportToolboxWrapper);
+  document.getElementById('dropdown_exportPreload').addEventListener
+      ('click', exportPreloadWrapper);
+  document.getElementById('dropdown_exportAll').addEventListener
+      ('click', exportAllWrapper);
   document.getElementById('button_export').addEventListener
       ('click', exportWrapper);
   document.getElementById('button_print').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -54,7 +54,7 @@ goog.require('goog.ui.ColorPicker');
 
     <div class='dropdown'>
     <button id="button_add">+</button>
-    <div id="dropdown_add" class="dropdown-content">
+    <div id="dropdownDiv_add" class="dropdown-content">
       <a id='dropdown_newCategory'>New Category</a>
       <a id='dropdown_loadCategory'>Standard Category</a>
       <a id='dropdown_separator'>Separator</a>
@@ -69,7 +69,7 @@ goog.require('goog.ui.ColorPicker');
     <p>&nbsp;</p>
     <div class='dropdown'>
     <button id="button_editCategory">Edit Category</button>
-    <div id="dropdown_editCategory" class="dropdown-content">
+    <div id="dropdownDiv_editCategory" class="dropdown-content">
       <a id='dropdown_name'>Name</a>
       <a id='dropdown_color'>Color</a>
     </div>
@@ -77,10 +77,10 @@ goog.require('goog.ui.ColorPicker');
 
     <div class='dropdown'>
     <button id="button_editShadow">Edit Block</button>
-    <div id="dropdown_editShadowAdd" class="dropdown-content">
+    <div id="dropdownDiv_editShadowAdd" class="dropdown-content">
       <a id='dropdown_addShadow'>Add Shadow</a>
     </div>
-    <div id="dropdown_editShadowRemove" class="dropdown-content">
+    <div id="dropdownDiv_editShadowRemove" class="dropdown-content">
       <a id='dropdown_removeShadow'>Remove Shadow</a>
     </div>
     </div>
@@ -489,19 +489,19 @@ goog.require('goog.ui.ColorPicker');
 
   // Wrappers to attach buttons to method calls for the controller object
   var addWrapper = function() {
-    document.getElementById('dropdown_add').classList.toggle("show");
+    document.getElementById('dropdownDiv_add').classList.toggle("show");
   };
   var newCategoryWrapper = function() {
     controller.addCategory();
-    document.getElementById('dropdown_add').classList.remove("show");
+    document.getElementById('dropdownDiv_add').classList.remove("show");
   };
   var loadCategoryWrapper = function() {
     controller.loadCategory();
-    document.getElementById('dropdown_add').classList.remove("show");
+    document.getElementById('dropdownDiv_add').classList.remove("show");
   };
   var separatorWrapper = function() {
     controller.addSeparator();
-    document.getElementById('dropdown_add').classList.remove("show");
+    document.getElementById('dropdownDiv_add').classList.remove("show");
   };
   var removeWrapper = function() {
     controller.removeElement();
@@ -519,19 +519,19 @@ goog.require('goog.ui.ColorPicker');
     controller.moveElement(1);
   };
   var editCategoryWrapper = function() {
-    document.getElementById('dropdown_editCategory').classList.toggle("show");
+    document.getElementById('dropdownDiv_editCategory').classList.toggle("show");
   };
   var nameWrapper = function() {
     controller.changeCategoryName();
-    document.getElementById('dropdown_editCategory').classList.remove("show");
+    document.getElementById('dropdownDiv_editCategory').classList.remove("show");
   };
   var shadowAddWrapper = function() {
     controller.addShadow();
-    document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+    document.getElementById('dropdownDiv_editShadowAdd').classList.remove("show");
   };
-    var shadowRemoveWrapper = function() {
+  var shadowRemoveWrapper = function() {
     controller.removeShadow();
-    document.getElementById('dropdown_editShadowRemove').classList.remove("show");
+    document.getElementById('dropdownDiv_editShadowRemove').classList.remove("show");
     // If turning invalid shadow block back to normal block, remove warning and disable
     // block editing privileges.
     Blockly.selected.setWarningText(null);
@@ -548,12 +548,12 @@ goog.require('goog.ui.ColorPicker');
         // has a surrounding parent), let the user make it a shadow block.
         // Use toggle instead of add so that the user can click the button again
         // to make the dropdown disappear without clicking one of the options.
-        document.getElementById('dropdown_editShadowRemove').classList.remove("show");
-        document.getElementById('dropdown_editShadowAdd').classList.toggle("show");
+        document.getElementById('dropdownDiv_editShadowRemove').classList.remove("show");
+        document.getElementById('dropdownDiv_editShadowAdd').classList.toggle("show");
       } else {
         // If the block is a shadow block, let the user make it a normal block.
-        document.getElementById('dropdown_editShadowAdd').classList.remove("show");
-        document.getElementById('dropdown_editShadowRemove').classList.toggle("show");
+        document.getElementById('dropdownDiv_editShadowAdd').classList.remove("show");
+        document.getElementById('dropdownDiv_editShadowRemove').classList.toggle("show");
       }
     }
   };
@@ -562,7 +562,7 @@ goog.require('goog.ui.ColorPicker');
   };
   var clearWrapper = function() {
     controller.clear();
-  }
+  };
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -592,10 +592,21 @@ goog.require('goog.ui.ColorPicker');
       ('change', importWrapper);
   document.getElementById('button_clear').addEventListener
       ('click', clearWrapper);
-  document.getElementById('dropdown_editShadowAdd').addEventListener
+  document.getElementById('dropdown_addShadow').addEventListener
       ('click', shadowAddWrapper);
-    document.getElementById('dropdown_editShadowRemove').addEventListener
+  document.getElementById('dropdown_removeShadow').addEventListener
       ('click', shadowRemoveWrapper);
+
+  // Use up and down arrow keys to move categories.
+  // TODO(evd2014): When merge with next CL for editing preloaded blocks, make sure
+  // mode is toolbox.
+  window.addEventListener('keydown', function(e) {
+    if (e.keyCode == 38) {    // Arrow up.
+      upWrapper();
+    } else if (e.keyCode == 40) {   // Arrow down.
+      downWrapper();
+    }
+  });
 
   // Create color picker with specific set of Blockly colors.
   var colorPicker = new goog.ui.ColorPicker();
@@ -607,7 +618,7 @@ goog.require('goog.ui.ColorPicker');
   popupPicker.setFocusable(true);
   goog.events.listen(popupPicker, 'change', function(e) {
         controller.changeSelectedCategoryColor(popupPicker.getSelectedColor());
-        document.getElementById('dropdown_editCategory').classList.remove
+        document.getElementById('dropdownDiv_editCategory').classList.remove
             ("show");
       });
 
@@ -655,8 +666,8 @@ goog.require('goog.ui.ColorPicker');
           // No block selected that is a shadow block or could be a valid shadow block.
           // Disable block editing.
           document.getElementById('button_editShadow').disabled = true;
-          document.getElementById('dropdown_editShadowRemove').classList.remove("show");
-          document.getElementById('dropdown_editShadowAdd').classList.remove("show");
+          document.getElementById('dropdownDiv_editShadowRemove').classList.remove("show");
+          document.getElementById('dropdownDiv_editShadowAdd').classList.remove("show");
         }
       }
     }

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -111,35 +111,32 @@ goog.require('goog.ui.ColorPicker');
   <aside id='preload_div' style='display:none'>
     <p>Configure the <a href="https://developers.google.com/blockly/guides/get-started/web">options</a> for your Blockly inject call.</p>
     <form id="workspace_options">
-      <input type="checkbox" id="collapse_checkbox" name="collapse" checked>Collapsible Blocks
-      <input type="checkbox" id="comments_checkbox" name="comments" checked>Comments for Blocks
-      <input type="checkbox" id="css_checkbox" name="css" checked>Use Blockly CSS
-      <input type="checkbox" id="disable_checkbox" name="disable" checked>Disabled Blocks
-      <input type="checkbox" id="grid_checkbox" name="grid" value="grid">Use Grid
-      <div id="grid_options" style="display:none">
-        Spacing <input type="text" id="grid_spacing_text" name="spacing" value="0">
-        Length <input type="text" id="grid_length_text" name="length" value="1">
-        Color <input type="text" id="grid_colour_text" name="colour" value="'#888'">
-        <input type="checkbox" value="grid_snap_checkbox" name="snap">Snap
+      <input type="checkbox" id="collapse_checkbox" name="collapse" checked>Collapsible Blocks<br>
+      <input type="checkbox" id="comments_checkbox" name="comments" checked>Comments for Blocks<br>
+      <input type="checkbox" id="css_checkbox" name="css" checked>Use Blockly CSS<br>
+      <input type="checkbox" id="disable_checkbox" name="disable" checked>Disabled Blocks<br>
+      <input type="checkbox" id="grid_checkbox" name="grid" value="grid">Use Grid<br>
+      <div id="grid_options" name="grid" style="display:none">
+        Spacing <input type="text" id="grid_spacing_text" name="spacing" custom="number" value="0"><br>
+        Length <input type="text" id="grid_length_text" name="length" custom="number"value="1"><br>
+        Color <input type="text" id="grid_colour_text" name="colour" custom="text" value="#888"><br>
+        <input type="checkbox" value="grid_snap_checkbox" name="snap">Snap<br>
       </div>
-      <input type="checkbox" id="maxBlocks_checkbox" name="maxBlocks" checked>Infinite Number of Blocks
-      <div id="maxBlocks_options" style="display:none">
-        Max Blocks <input type="text" id="maxBlocksValue_text" name="maxBlocks" value="0">
-      </div>
-      Path to Blockly Media <input type="text" id="media_text" name="media" value='https://blockly-demo.appspot.com/static/media/'>
-      <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only
-      <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL
-      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars" checked>Scrollbars
-      <input type="checkbox" id="sounds_checkbox" name="sounds" checked>Sounds
-      <input type="checkbox" id="trashbox_checkbox" name="trashbox" checked>Trashcan
-      <input type="checkbox" id="zoom_checkbox" name="zoom" value="zoom">Zoom
-      <div id="zoom_options" style="display:none">
-        <input type="checkbox" id="zoom_controls_checkbox" name="controls">Zoom Controls
-        <input type="checkbox" id="zoom_wheel_checkbox" name="wheel">Zoom Wheel
-        Start Scale <input type="text" id="zoom_startScale_text" name="startScale" value="1.0">
-        Max Scale <input type="text" id="zoom_maxScale_text" name="maxScale" value="3">
-        Min Scale <input type="text" id="zoom_minScale_text" name="minScale" value="0.3">
-        Scale Speed <input type="text" id="zoom_scaleSpeed_text" name="scaleSpeed" value="1.2">
+      Max Blocks <input type="text" id="maxBlocksValue_text" name="maxBlocks" custom="number" value="Infinity"><br>
+      Path to Blockly Media <input type="text" id="media_text" name="media" custom="text" value='https://blockly-demo.appspot.com/static/media/'><br>
+      <input type="checkbox" id="readOnly_checkbox" name="readOnly">Read Only<br>
+      <input type="checkbox" id="rtl_checkbox" name="rtl">Layout with RTL<br>
+      <input type="checkbox" id="scrollbars_checkbox" name="scrollbars" checked>Scrollbars<br>
+      <input type="checkbox" id="sounds_checkbox" name="sounds" checked>Sounds<br>
+      <input type="checkbox" id="trashcan_checkbox" name="trashcan" checked>Trashcan<br>
+      <input type="checkbox" id="zoom_checkbox" name="zoom">Zoom<br>
+      <div id="zoom_options" name="zoom" style="display:none">
+        <input type="checkbox" id="zoom_controls_checkbox" name="controls">Zoom Controls<br>
+        <input type="checkbox" id="zoom_wheel_checkbox" name="wheel">Zoom Wheel<br>
+        Start Scale <input type="text" id="zoom_startScale_text" name="startScale" custom="number" value="1.0"><br>
+        Max Scale <input type="text" id="zoom_maxScale_text" name="maxScale" custom="number" value="3"><br>
+        Min Scale <input type="text" id="zoom_minScale_text" name="minScale" custom="number" value="0.3"><br>
+        Scale Speed <input type="text" id="zoom_scaleSpeed_text" name="scaleSpeed" custom="number" value="1.2"><br>
       </div>
     </form>
   </aside>
@@ -807,57 +804,142 @@ goog.require('goog.ui.ColorPicker');
     }
   });
 
+  //UNIFY
   document.getElementById('grid_checkbox').addEventListener('change', function(e) {
       document.getElementById('grid_options').style.display = document.getElementById('grid_checkbox').checked ? 'block' : 'none';
+      if (!document.getElementById('grid_checkbox').checked) {
+        controller.removeOption('grid');
+      } else {
+        var options = document.getElementById('grid_options').children;
+        for (var i = 0, option; option = options[i]; i++) {
+          if (option.type == 'checkbox') {
+            controller.setOptions(option.name, option.checked, 'grid');
+          } else {
+            var value = option.value;
+            if (type = option.getAttribute('custom') == 'number') {
+              value = parseInt(value);
+            }
+            controller.setOptions(option.name, value, 'grid');
+          }
+        }
+      }
   });
+  // MOVE TO METHOD IN CONTROLLER
   document.getElementById('zoom_checkbox').addEventListener('change', function(e) {
       document.getElementById('zoom_options').style.display = document.getElementById('zoom_checkbox').checked ? 'block' : 'none';
+      if (!document.getElementById('zoom_checkbox').checked) {
+        controller.removeOption('zoom');
+      } else {
+        var options = document.getElementById('zoom_options').children;
+        for (var i = 0, option; option = options[i]; i++) {
+          if (option.type == 'checkbox') {
+            controller.setOptions(option.name, option.checked, 'zoom');
+          } else {
+            var value = option.value;
+            if (type = option.getAttribute('custom') == 'number') {
+              value = parseInt(value);
+            }
+            controller.setOptions(option.name, value, 'zoom');
+          }
+        }
+      }
   });
-  document.getElementById('maxBlocks_checkbox').addEventListener('change', function(e) {
-      document.getElementById('maxBlocks_options').style.display = document.getElementById('maxBlocks_checkbox').checked ? 'none' : 'block';
-  });
+  // document.getElementById('maxBlocks_checkbox').addEventListener('change', function(e) {
+  //     document.getElementById('maxBlocks_options').style.display = document.getElementById('maxBlocks_checkbox').checked ? 'none' : 'block';
+  // });
 
-  document.getElementById('comments_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('comments', document.getElementById('comments_checkbox').checked);
-  });
-  document.getElementById('css_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('css', document.getElementById('css_checkbox').checked);
-  });
-  document.getElementById('disable_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('disable', document.getElementById('disable_checkbox').checked);
-  });
-  document.getElementById('readOnly_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('readOnly', document.getElementById('readOnly_checkbox').checked);
-  });
-  document.getElementById('rtl_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('rtl', document.getElementById('rtl_checkbox').checked);
-  });
-  document.getElementById('scrollbars_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('scrollbars', document.getElementById('scrollbars_checkbox').checked);
-  });
-  document.getElementById('sounds_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('sounds', document.getElementById('sounds_checkbox').checked);
-  });
-  document.getElementById('trashbox_checkbox').addEventListener('change', function(e) {
-      controller.setOptions('trashbox', document.getElementById('trashbox_checkbox').checked);
-  });
+  // document.getElementById('comments_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('comments', document.getElementById('comments_checkbox').checked);
+  // });
+  // document.getElementById('css_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('css', document.getElementById('css_checkbox').checked);
+  // });
+  // document.getElementById('disable_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('disable', document.getElementById('disable_checkbox').checked);
+  // });
+  // document.getElementById('readOnly_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('readOnly', document.getElementById('readOnly_checkbox').checked);
+  // });
+  // document.getElementById('rtl_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('rtl', document.getElementById('rtl_checkbox').checked);
+  // });
+  // document.getElementById('scrollbars_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('scrollbars', document.getElementById('scrollbars_checkbox').checked);
+  // });
+  // document.getElementById('sounds_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('sounds', document.getElementById('sounds_checkbox').checked);
+  // });
+  // document.getElementById('trashbox_checkbox').addEventListener('change', function(e) {
+  //     controller.setOptions('trashbox', document.getElementById('trashbox_checkbox').checked);
+  // });
 
   var options = document.getElementById('workspace_options').children;
   for (var i = 0, option; option = options[i]; i++) {
-    if (option.tagName != 'div' && option.name) {
+    console.log('ID: ' + option.id);
+    if (option.tagName != 'DIV' && option.name && option.name != 'grid' && option.name !='zoom') {
+      var name = option.name;
+      var id = option.id;
       if (option.type == 'checkbox') {
         controller.setOptions(option.name, option.checked);
-        option.addEventListener('change', function(option, controller) {
+        option.addEventListener('change', function(optionName, optionId) {
           return function() {
-            controller.setOptions(option.name, option.checked);
+            var checked = document.getElementById(optionId).checked;
+            console.log(checked + ' ' + optionName);
+            controller.setOptions(optionName, checked);
           };
-        }());
+        }(name, id));
       } else {
         controller.setOptions(option.name, option.value);
-        option.addEventListener('change', function(e) {
-          controller.setOptions(option.name, option.checked);
-        });
+        var type = option.getAttribute('custom');
+        option.addEventListener('change', function(optionName, optionId, optionType) {
+          return function() {
+            var value = document.getElementById(optionId).value
+            if (optionType == 'number') {
+              console.log("parsing");
+              value = parseInt(value);
+            }
+            console.log(value + ' ' + optionName);
+            controller.setOptions(optionName, value);
+          };
+        }(name, id, type));
       }
+    } else if (option.id == 'grid_options' || option.id == 'zoom_options') {
+      var subOptions = option.children;
+      console.log(option.name);
+      console.log(subOptions.length);
+      for (var j = 0, subOption; subOption = subOptions[j]; j++) {
+        if (subOption.name) {
+          var subName = subOption.name;
+          var id = subOption.id;
+          var name = option.getAttribute('name');
+          console.log(name);
+          if (subOption.type == 'checkbox') {
+            // controller.setOptions(subOption.name, subOption.checked, name);
+            subOption.addEventListener('change', function(optionName, subOptionName, subOptionId) {
+              return function() {
+                var checked = document.getElementById(subOptionId).checked;
+                console.log(checked + ' ' + optionName + ' ' + subOptionName);
+                controller.setOptions(subOptionName, checked, optionName);
+              };
+            }(name, subName, id));
+          } else {
+            // controller.setOptions(subOption.name, subOption.value, name);
+            var type = subOption.getAttribute('custom');
+            subOption.addEventListener('change', function(optionName, subOptionName, subOptionId, subOptionType) {
+              return function() {
+                var value = document.getElementById(subOptionId).value
+                if (subOptionType == 'number') {
+                  console.log("parsing");
+                  value = parseInt(value);
+                }
+                console.log(value + ' ' + subOptionName);
+                controller.setOptions(subOptionName, value, optionName);
+              };
+            }(name, subName, id, type));
+          }
+        }
+      }
+      console.log('done with iteration of for loop');
     }
   }
 

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -636,32 +636,11 @@ goog.require('goog.ui.ColorPicker');
     controller.importFile(event.target.files[0], FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
-  var exportToolboxWrapper = function() {
-    controller.exportFile(FactoryController.MODE_TOOLBOX);
-    document.getElementById('dropdownDiv_export').classList.remove("show");
-  }
-  var exportPreloadWrapper = function() {
-    controller.exportFile(FactoryController.MODE_PRELOAD);
-    document.getElementById('dropdownDiv_export').classList.remove("show");
-  }
-  var exportAllWrapper = function() {
-    controller.exportFile(FactoryController.MODE_TOOLBOX);
-    controller.exportFile(FactoryController.MODE_PRELOAD);
-    document.getElementById('dropdownDiv_export').classList.remove("show");
-  }
   var editToolboxWrapper = function() {
     controller.setMode(FactoryController.MODE_TOOLBOX);
   };
   var editPreloadWrapper = function() {
     controller.setMode(FactoryController.MODE_PRELOAD);
-  };
-  var importToolboxWrapper = function(e) {
-    controller.importFile(event.target.files[0], true);
-    document.getElementById('dropdownDiv_import').classList.remove("show");
-  };
-  var importPreloadWrapper = function(e) {
-    controller.importFile(event.target.files[0], FactoryController.MODE_PRELOAD);
-    document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var exportToolboxWrapper = function() {
     controller.exportFile(FactoryController.MODE_TOOLBOX);

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -828,7 +828,7 @@ goog.require('goog.ui.ColorPicker');
       if (!document.getElementById('grid_checkbox').checked) {
         controller.removeOption('grid');
       } else {
-        controller.openAndApplySubOptions('grid', document.getElementById('grid_options').children);
+        controller.applySubOptions('grid', document.getElementById('grid_options').children);
       }
   });
 
@@ -840,7 +840,7 @@ goog.require('goog.ui.ColorPicker');
       if (!document.getElementById('zoom_checkbox').checked) {
         controller.removeOption('zoom');
       } else {
-        controller.openAndApplySubOptions('zoom', document.getElementById('zoom_options').children);
+        controller.applySubOptions('zoom', document.getElementById('zoom_options').children);
       }
   });
 

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -656,7 +656,7 @@ goog.require('goog.ui.ColorPicker');
       ('click', clearWrapper);
   document.getElementById('dropdown_addShadow').addEventListener
       ('click', shadowAddWrapper);
-  document.getElementById('dropdown_editShadowRemove').addEventListener
+  document.getElementById('dropdown_removeShadow').addEventListener
       ('click', shadowRemoveWrapper);
   document.getElementById('tab_toolbox').addEventListener
       ('click', editToolboxWrapper);

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -581,6 +581,7 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
+<<<<<<< 8d894a801cfe834cbaa1a468d1430524e90e4527
   var importWrapper = function() {
     document.getElementById('dropdownDiv_import').classList.toggle("show");
     document.getElementById('dropdownDiv_export').classList.remove("show");
@@ -617,10 +618,18 @@ goog.require('goog.ui.ColorPicker');
   }
   var editToolboxWrapper = function() {
     controller.setMode(FactoryController.MODE_TOOLBOX);
-  }
+  };
   var editPreloadWrapper = function() {
     controller.setMode(FactoryController.MODE_PRELOAD);
-  }
+  };
+  var importToolboxWrapper = function(e) {
+    controller.importFile(event.target.files[0], true);
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
+  var importPreloadWrapper = function(e) {
+    controller.importFile(event.target.files[0]), false;
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -701,6 +701,7 @@ goog.require('goog.ui.ColorPicker');
     // blocks when dragging them into workspace. Could cause problems if ever load
     // blocks into workspace directly without calling updatePreview.
     if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
+      controller.saveStateFromWorkspace();
       controller.updatePreview();
     }
 

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -30,10 +30,26 @@ goog.require('goog.ui.ColorPicker');
   <tr>
     <td>
       <p>
-        <input type="file" id="input_import" class="inputfile"></input>
-        <label for="input_import">Import</label>
+        <div class="dropdown">
+        <button id="button_import">Import</button>
+        <div id="dropdownDiv_import" class="dropdown-content">
+          <input type="file" id="input_importToolbox" class="inputfile"></input>
+          <label for="input_importToolbox">Toolbox</label>
+          <input type="file" id="input_importPreload" class="inputfile"></input>
+          <label for="input_importPreload">Workspace Blocks</label>
+        </div>
+        </div>
+
+        <div class="dropdown">
         <button id="button_export">Export</button>
-        <button id="button_print">Print</button>
+        <div id="dropdownDiv_export" class="dropdown-content">
+          <a id='dropdown_exportToolbox'>Toolbox</a>
+          <a id='dropdown_exportPreload'>Workspace Blocks</a>
+          <a id='dropdown_exportAll'>All</a>
+        </div>
+        </div>
+
+        <button id="button_print">Print Toolbox</button>
         <button id="button_clear">Clear</button>
       </p>
     </td>
@@ -514,7 +530,8 @@ goog.require('goog.ui.ColorPicker');
     controller.removeElement();
   };
   var exportWrapper = function() {
-    controller.exportConfig();
+    document.getElementById('dropdownDiv_export').classList.toggle("show");
+    //controller.exportConfig();
   };
   var printWrapper = function() {
     controller.printConfig();
@@ -564,18 +581,27 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
-  var importWrapper = function(event) {
-    controller.importFile(event.target.files[0]);
+  var importWrapper = function() {  // took an event e before, need to have listener with 'change' for files
+    document.getElementById('dropdownDiv_import').classList.toggle("show");
+    //controller.importFile(event.target.files[0]);
   };
   var clearWrapper = function() {
     controller.clear();
   };
   var editToolboxWrapper = function() {
     controller.setMode(FactoryController.MODE_TOOLBOX);
-  }
+  };
   var editPreloadWrapper = function() {
     controller.setMode(FactoryController.MODE_PRELOAD);
-  }
+  };
+  var importToolboxWrapper = function(e) {
+    controller.importFile(event.target.files[0], true);
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
+  var importPreloadWrapper = function(e) {
+    controller.importFile(event.target.files[0]), false;
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -601,8 +627,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', editShadowWrapper);
   document.getElementById('dropdown_name').addEventListener
       ('click', nameWrapper);
-  document.getElementById('input_import').addEventListener
-      ('change', importWrapper);
+  document.getElementById('button_import').addEventListener
+      ('click', importWrapper);
+  document.getElementById('input_importToolbox').addEventListener
+      ('change', importToolboxWrapper);
+  document.getElementById('input_importPreload').addEventListener
+      ('change', importPreloadWrapper);
   document.getElementById('button_clear').addEventListener
       ('click', clearWrapper);
   document.getElementById('dropdown_addShadow').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -42,11 +42,15 @@ goog.require('goog.ui.ColorPicker');
 
 <section id="createDiv">
   <p>Drag blocks into your toolbox:</p>
+  <table id='workspaceTabs'>
+    <td id="tab_toolbox" class="tabon">Toolbox</td>
+    <td id="tab_preload" class="taboff">Pre-loaded Workspace</td>
+  </table>
   <section id="toolbox_section">
     <div id="toolbox_blocks" class="content"></div>
     <div id='disable_div'></div>
   </section>
-  <aside id="category_section">
+  <aside id="toolbox_div">
     <table id="categoryTable">
       <td id="tab_help">Your categories will appear here</td>
     </table>
@@ -75,7 +79,11 @@ goog.require('goog.ui.ColorPicker');
     </div>
     </div>
 
-    <div class='dropdown'>
+  </aside>
+  <aside id='preload_div' style='display:none'>
+  </aside>
+
+  <div class='dropdown'>
     <button id="button_editShadow">Edit Block</button>
     <div id="dropdownDiv_editShadowAdd" class="dropdown-content">
       <a id='dropdown_addShadow'>Add Shadow</a>
@@ -83,9 +91,8 @@ goog.require('goog.ui.ColorPicker');
     <div id="dropdownDiv_editShadowRemove" class="dropdown-content">
       <a id='dropdown_removeShadow'>Remove Shadow</a>
     </div>
-    </div>
+  </div>
 
-  </aside>
 </section>
 
 <aside id="previewDiv">
@@ -563,6 +570,12 @@ goog.require('goog.ui.ColorPicker');
   var clearWrapper = function() {
     controller.clear();
   };
+  var editToolboxWrapper = function() {
+    controller.setTab(FactoryController.TAB_TOOLBOX);
+  }
+  var editPreloadWrapper = function() {
+    controller.setTab(FactoryController.TAB_PRELOAD);
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -594,8 +607,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', clearWrapper);
   document.getElementById('dropdown_addShadow').addEventListener
       ('click', shadowAddWrapper);
-  document.getElementById('dropdown_removeShadow').addEventListener
+  document.getElementById('dropdown_editShadowRemove').addEventListener
       ('click', shadowRemoveWrapper);
+  document.getElementById('tab_toolbox').addEventListener
+      ('click', editToolboxWrapper);
+  document.getElementById('tab_preload').addEventListener
+      ('click', editPreloadWrapper);
 
   // Use up and down arrow keys to move categories.
   // TODO(evd2014): When merge with next CL for editing preloaded blocks, make sure

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -41,7 +41,7 @@ goog.require('goog.ui.ColorPicker');
 </table>
 
 <section id="createDiv">
-  <p>Drag blocks into your toolbox:</p>
+  <p id="editHelpText">Drag blocks into your toolbox:</p>
   <table id='workspaceTabs'>
     <td id="tab_toolbox" class="tabon">Toolbox</td>
     <td id="tab_preload" class="taboff">Pre-loaded Workspace</td>
@@ -571,10 +571,10 @@ goog.require('goog.ui.ColorPicker');
     controller.clear();
   };
   var editToolboxWrapper = function() {
-    controller.setTab(FactoryController.TAB_TOOLBOX);
+    controller.setMode(FactoryController.MODE_TOOLBOX);
   }
   var editPreloadWrapper = function() {
-    controller.setTab(FactoryController.TAB_PRELOAD);
+    controller.setMode(FactoryController.MODE_PRELOAD);
   }
 
   document.getElementById('button_add').addEventListener

--- a/demos/blocklyfactory/workspacefactory/standard_categories.js
+++ b/demos/blocklyfactory/workspacefactory/standard_categories.js
@@ -1,4 +1,24 @@
 /**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * @fileoverview Contains a map of standard Blockly categories used to load
  * standard Blockly categories into the user's toolbox. The map is keyed by
  * the lower case name of the category, and contains the Category object for

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -21,6 +21,10 @@ aside {
   border-bottom: none;
 }
 
+#workspaceTabs>table {
+  float: right;
+}
+
 td.tabon {
   border-bottom-color: #ddd !important;
   background-color: #ddd;
@@ -135,7 +139,7 @@ td {
   width: 30%;
 }
 
-#category_section {
+#toolbox_div {
   width: 20%;
 }
 

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -201,6 +201,13 @@ td {
   text-decoration: none;
 }
 
+.dropdown-content label {
+    color: black;
+    display: block;
+    padding: 12px 16px;
+    text-decoration: none;
+}
+
 /* Change color of dropdown links on hover */
 .dropdown-content a:hover {
   background-color: #f1f1f1

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -116,6 +116,10 @@ td {
   width: 20%;
 }
 
+#preload_div {
+  width: 20%;
+}
+
 #disable_div {
   background-color: white;
   height: 100%;

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -67,6 +67,10 @@ button:hover:not(:disabled)>* {
   opacity: 1;
 }
 
+button.small {
+  font-size: small;
+}
+
 table {
   border: none;
   border-collapse: collapse;

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -63,33 +63,6 @@ button:hover:not(:disabled)>* {
   opacity: 1;
 }
 
-label {
-  border-radius: 4px;
-  border: 1px solid #ddd;
-  background-color: #eee;
-  color: #000;
-  font-size: large;
-  margin: 0 5px;
-  padding: 10px;
-}
-
-label:hover:not(:disabled) {
-  box-shadow: 2px 2px 5px #888;
-}
-
-label:disabled {
-  opacity: .6;
-}
-
-label>* {
-  opacity: .6;
-  vertical-align: text-bottom;
-}
-
-label:hover:not(:disabled)>* {
-  opacity: 1;
-}
-
 table {
   border: none;
   border-collapse: collapse;
@@ -217,8 +190,19 @@ td {
     text-decoration: none;
 }
 
+.dropdown-content label {
+    color: black;
+    display: block;
+    padding: 12px 16px;
+    text-decoration: none;
+}
+
 /* Change color of dropdown links on hover */
 .dropdown-content a:hover {
+  background-color: #f1f1f1
+}
+
+.dropdown-content label:hover {
   background-color: #f1f1f1
 }
 

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -21,10 +21,6 @@ aside {
   border-bottom: none;
 }
 
-#workspaceTabs>table {
-  float: right;
-}
-
 td.tabon {
   border-bottom-color: #ddd !important;
   background-color: #ddd;

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -173,28 +173,28 @@ td {
 
 /* Dropdown Content (Hidden by Default) */
 .dropdown-content {
-    background-color: #f9f9f9;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,.2);
-    display: none;
-    min-width: 170px;
-    opacity: 1;
-    position: absolute;
-    z-index: 1;
+  background-color: #f9f9f9;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,.2);
+  display: none;
+  min-width: 170px;
+  opacity: 1;
+  position: absolute;
+  z-index: 1;
 }
 
 /* Links inside the dropdown */
 .dropdown-content a {
-    color: black;
-    display: block;
-    padding: 12px 16px;
-    text-decoration: none;
+  color: black;
+  display: block;
+  padding: 12px 16px;
+  text-decoration: none;
 }
 
 .dropdown-content label {
-    color: black;
-    display: block;
-    padding: 12px 16px;
-    text-decoration: none;
+  color: black;
+  display: block;
+  padding: 12px 16px;
+  text-decoration: none;
 }
 
 /* Change color of dropdown links on hover */

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -21,6 +21,10 @@ aside {
   border-bottom: none;
 }
 
+#workspaceTabs>table {
+  float: right;
+}
+
 td.tabon {
   border-bottom-color: #ddd !important;
   background-color: #ddd;

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -960,7 +960,6 @@ FactoryController.prototype.setOptionAndUpdate = function(type, value,
   if (!opt_parentOption) {
     this.model.setOption(type, value);
   } else {
-    console.log("calling suboption for " + opt_parentOption);
     this.model.setSubOption(opt_parentOption, type, value);
   }
   this.reinjectPreview(Blockly.Options.parseToolboxTree

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -109,7 +109,7 @@ FactoryController.prototype.addCategory = function() {
 
    // Allow the user to use the default options for injecting the workspace
   // when there are categories if adding the first category.
-  if (firstCategory) {
+  if (isFirstCategory) {
     this.allowToSetDefaultOptions();
   }
   // Update preview.
@@ -433,6 +433,8 @@ FactoryController.prototype.reinjectPreview = function(tree) {
   this.previewWorkspace.dispose();
   this.model.setOptionsAttribute('toolbox', Blockly.Xml.domToPrettyText(tree));
   this.previewWorkspace = Blockly.inject('preview_blocks', this.model.options);
+  Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
+      this.previewWorkspace);
 };
 
 /**
@@ -575,7 +577,7 @@ FactoryController.prototype.loadCategory = function() {
   this.convertShadowBlocks_();
   // Save state from workspace before updating preview.
   this.saveStateFromWorkspace();
-  if (firstCategory) {
+  if (isFirstCategory) {
     // Allow the user to use the default options for injecting the workspace
     // when there are categories.
     this.allowToSetDefaultOptions();
@@ -803,7 +805,7 @@ FactoryController.prototype.importPreloadFromTree_ = function(tree) {
  */
 FactoryController.prototype.clearToolbox = function() {
   this.setMode(FactoryController.MODE_TOOLBOX);
-  var hasCategories = this.model.hasToolbox();
+  var hasCategories = this.model.hasElements();
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
   this.view.addEmptyCategoryMessage();
@@ -953,7 +955,7 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
  */
 FactoryController.prototype.setStandardOptionsAndUpdate = function() {
   this.view.setBaseOptions();
-  this.view.setCategoryOptions(this.model.hasToolbox());
+  this.view.setCategoryOptions(this.model.hasElements());
   this.generateNewOptions();
  };
 
@@ -966,16 +968,16 @@ FactoryController.prototype.setStandardOptionsAndUpdate = function() {
  * categories or a single flyout are used.
  */
 FactoryController.prototype.allowToSetDefaultOptions = function() {
-  if (!this.model.hasToolbox() && !confirm('Do you want to use the default ' +
+  if (!this.model.hasElements() && !confirm('Do you want to use the default ' +
       'workspace configuration options for injecting a workspace without ' +
       'categories?')) {
     return;
-  } else if (this.model.hasToolbox() && !confirm('Do you want to use the ' +
+  } else if (this.model.hasElements() && !confirm('Do you want to use the ' +
       'default workspace configuration options for injecting a workspace ' +
       'with categories?')) {
     return;
   }
-  this.view.setCategoryOptions(this.model.hasToolbox());
+  this.view.setCategoryOptions(this.model.hasElements());
   this.generateNewOptions();
 };
 
@@ -1045,22 +1047,3 @@ FactoryController.prototype.generateNewOptions = function() {
       (this.generator.generateToolboxXml()));
 };
 
-/**
- * Given the name of an input DOM element and the type of input field, returns
- * the value that should be recorded in the options object.
- * @private
- *
- * @param {!string} optionId The ID of the input DOM element for an option.
- * @param {!string} type The type of input for that DOM element ('checkbox',
- *    'number', or 'text').
- */
-FactoryController.prototype.getOptionValue_ = function(optionId, type) {
-  var option = document.getElementById(optionId);
-  if (type == 'checkbox') {
-    return option.checked;
-  } else  if (type == 'number') {
-    return parseInt(option.value);
-  } else if (type == 'text') {
-    return option.value;
-  }
-};

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -336,9 +336,6 @@ FactoryController.prototype.updatePreview = function() {
 
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
-    // Capture any changes made by user before generating XML.
-    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
->>>>>>> Have import/export functionality complete
     // Get toolbox XML.
     var tree = Blockly.Options.parseToolboxTree
         (this.generator.generateToolboxXml());
@@ -386,7 +383,11 @@ FactoryController.prototype.saveStateFromWorkspace = function() {
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
     this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+<<<<<<< 5c38b1f7f28b9490385f0649e2c7ebd6b2f348f4
   } else if (this.selectedMode == FactoryController.MODE_PRELOAD) {
+=======
+  } else {
+>>>>>>> Added saveStateFromWorkspace, changed the names of some variables and methods
     // If currently editing the pre-loaded workspace.
     this.model.savePreloadXml
         (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
@@ -719,6 +720,7 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
 
   this.saveStateFromWorkspace();
 
+  this.saveStateFromWorkspace();
   this.updatePreview();
 };
 
@@ -733,6 +735,7 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
 FactoryController.prototype.importPreloadFromTree_ = function(tree) {
   this.clearAndLoadXml_(tree);
   this.model.savePreloadXml(tree);
+  this.saveStateFromWorkspace();
   this.updatePreview();
 }
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -628,7 +628,7 @@ FactoryController.prototype.importFile = function(file, importMode) {
   reader.onload = function() {
     // Try to parse XML from file and load it into toolbox editing area.
     // Print error message if fail.
-    //try {
+    try {
       var tree = Blockly.Xml.textToDom(reader.result);
       if (importMode == FactoryController.MODE_TOOLBOX) {
         // Switch mode and import toolbox XML.
@@ -724,12 +724,18 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
   this.updatePreview();
 };
 
+/**
+ * Given a XML DOM tree, loads it into the pre-loaded workspace editing area.
+ * Assumes that tree is in valid XML format and that the selected mode is
+ * MODE_PRELOAD.
+ *
+ * @param {!Element} tree XML tree to be loaded to pre-loaded block editing
+ *    area.
+ */
 FactoryController.prototype.importPreloadFromTree_ = function(tree) {
   this.clearAndLoadXml_(tree);
   this.model.savePreloadXml(tree);
-  this.updatePreview(); //assuming that updatePreview still calls domToWorkspace regardless of mode
-  // this.previewWorkspace.domToWorkspace
-  //     (this.generator.generateWorkspaceXml(tree));
+  this.updatePreview();
 }
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -275,10 +275,7 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
  *    (FactoryController.MODE_TOOLBOX for the toolbox configuration, and
  *    FactoryController.MODE_PRELOAD for the pre-loaded workspace configuration)
  */
-FactoryController.prototype.exportFile = function(exportMode) {
-  // Save workspace in current state.
-  this.saveStateFromWorkspace();
-
+FactoryController.prototype.exportXmlFile = function(exportMode) {
   // Generate XML.
   if (exportMode == FactoryController.MODE_TOOLBOX) {
     // Export the toolbox XML.
@@ -306,6 +303,16 @@ FactoryController.prototype.exportFile = function(exportMode) {
   var data = new Blob([configXml], {type: 'text/xml'});
   this.view.createAndDownloadFile(fileName, data);
  };
+
+FactoryController.prototype.exportOptionsFile = function() {
+  var fileName = prompt('File Name for options object for injecting: ');
+  if (!fileName) {  // If cancelled.
+    return;
+  }
+  // Prettify?
+  var data = new Blob([JSON.stringify(this.model.options)], {type: 'text/plain'});
+  this.view.createAndDownloadFile(fileName, data);
+};
 
 /**
  * Tied to "Print" button. Mainly used for debugging purposes. Prints

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -311,7 +311,7 @@ FactoryController.prototype.reinjectPreview = function(tree) {
        length: 3,
        colour: '#ccc',
        snap: true},
-     media: '../../media/',
+     media: '../../../media/',
      toolbox: previewToolbox,
      zoom:
        {controls: true,

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -252,6 +252,7 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
     // Set next category.
     this.model.setSelectedById(id);
 
+<<<<<<< f68f7c4a490dfb2ccc0db7b8f44930dc316ee38b
     // Clears workspace and loads next category.
     this.clearAndLoadXml_(this.model.getSelectedXml());
 
@@ -261,6 +262,16 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
     // Order blocks as if shown in the flyout.
     this.toolboxWorkspace.cleanUp_();
   }
+=======
+  // Clears workspace and loads next category.
+  this.clearAndLoadXml_(this.model.getSelectedXml());
+
+  // Selects the next tab.
+  this.view.setCategoryTabSelection(id, true);
+
+  // Order blocks as if shown in the flyout.
+  this.toolboxWorkspace.cleanUp_();
+>>>>>>> Have basic pre-loaded workspace working
 
   // Update category editing buttons.
   this.view.updateState(this.model.getIndexByElementId
@@ -331,6 +342,7 @@ FactoryController.prototype.updatePreview = function() {
   // Disable events to stop updatePreview from recursively calling itself
   // through event handlers.
   Blockly.Events.disable();
+<<<<<<< f68f7c4a490dfb2ccc0db7b8f44930dc316ee38b
 
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
@@ -813,7 +825,6 @@ FactoryController.prototype.convertShadowBlocks = function() {
   }
 };
 
-<<<<<<< b52dd61f1b76c06b816c73ff4dccfce9fa9fd74f
 /**
  * Sets the currently selected mode that determines what the toolbox workspace
  * is being used to edit. Updates the view and then saves and loads XML
@@ -848,6 +859,8 @@ FactoryController.prototype.setMode = function(mode) {
         (this.model.getSelected()));
   } else {
     // Open the pre-loaded workspace editing space.
+    document.getElementById('editHelpText').textContent =
+        'Drag blocks into your pre-loaded workspace:';
     if (this.model.getSelected()) {
       this.model.getSelected().saveFromWorkspace(this.toolboxWorkspace);
     }
@@ -870,3 +883,4 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
   this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
       (this.toolboxWorkspace.getAllBlocks()));
 }
+

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -89,7 +89,9 @@ FactoryController.prototype.addCategory = function() {
       // Create the new category.
       this.createCategory(name, true);
       // Set the new category as selected.
-      this.model.setSelectedById(this.model.getCategoryIdByName(name));
+      var id = this.model.getCategoryIdByName(name);
+      this.model.setSelectedById(id);
+      this.view.setCategoryTabSelection(id, true);
       // Allow user to use the default options for injecting with categories.
       this.allowToSetDefaultOptions();
     }

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -253,15 +253,42 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
 };
 
 /**
- * Tied to "Export Config" button. Gets a file name from the user and downloads
+ * Tied to "Export" button. Gets a file name from the user and downloads
  * the corresponding configuration xml to that file.
+ *
+ * @param {!string} exportMode The type of file to export
+ *    (FactoryController.MODE_TOOLBOX for the toolbox configuration, and
+ *    FactoryController.MODE_PRELOAD for the pre-loaded workspace configuration)
  */
-FactoryController.prototype.exportConfig = function() {
+FactoryController.prototype.exportFile = function(exportMode) {
   // Generate XML.
-  var configXml = Blockly.Xml.domToPrettyText
-      (this.generator.generateConfigXml(this.toolboxWorkspace));
+  if (exportMode == FactoryController.MODE_TOOLBOX) {
+    // Export the toolbox XML.
+    if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
+      // Capture any changes made by user before generating XML if in
+      // toolbox mode.
+      this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+    }
+    var configXml = Blockly.Xml.domToPrettyText
+        (this.generator.generateToolboxXml());
+  } else if (exportMode == FactoryController.MODE_PRELOAD) {
+    // Export the pre-loaded block XML.
+    if (this.selectedMode == FactoryController.MODE_PRELOAD) {
+      // Capture any changes made by user before generating XML if in
+      // preload workspace mode.
+      this.model.savePreloadXml(Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+    }
+    var configXml = Blockly.Xml.domToPrettyText
+        (this.generator.generateWorkspaceXml());
+  } else {
+    // Unknown mode. Throw error.
+    throw new Error ("Unknown export mode: " + exportMode);
+  }
+
   // Get file name.
-  var fileName = prompt("File Name: ");
+  var fileName = prompt('File Name for ' + (exportMode ==
+      FactoryController.MODE_TOOLBOX ? 'toolbox XML: ' :
+      'pre-loaded workspace XML: '));
   if (!fileName) { // If cancelled
     return;
   }
@@ -271,12 +298,15 @@ FactoryController.prototype.exportConfig = function() {
  };
 
 /**
- * Tied to "Print Config" button. Mainly used for debugging purposes. Prints
+ * Tied to "Print" button. Mainly used for debugging purposes. Prints
  * the configuration XML to the console.
  */
 FactoryController.prototype.printConfig = function() {
+  // Capture any changes made by user before generating XML.
+  this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+  // Print XML.
   window.console.log(Blockly.Xml.domToPrettyText
-      (this.generator.generateConfigXml(this.toolboxWorkspace)));
+      (this.generator.generateToolboxXml()));
 };
 
 /**
@@ -294,9 +324,12 @@ FactoryController.prototype.updatePreview = function() {
 
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
+    // Capture any changes made by user before generating XML.
+    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+    // Get toolbox XML.
     var tree = Blockly.Options.parseToolboxTree
-        (this.generator.generateConfigXml(this.toolboxWorkspace));
-
+        (this.generator.generateToolboxXml());
+    // No categories, creates a simple flyout.
     if (tree.getElementsByTagName('category').length == 0) {
       // No categories, creates a simple flyout.
       if (this.previewWorkspace.toolbox_) {
@@ -318,13 +351,14 @@ FactoryController.prototype.updatePreview = function() {
     // blocks don't get cleared when updating preview from event listeners while
     // switching modes.
     this.previewWorkspace.clear();
-    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
-        (this.model.getPreloadXml()), this.previewWorkspace);
+    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
+        this.previewWorkspace);
   } else {
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
-    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
-        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)),
+    this.model.savePreloadXml
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
   }
 
@@ -544,16 +578,20 @@ FactoryController.prototype.addSeparator = function() {
 
 /**
  * Connected to the import button. Given the file path inputted by the user
- * from file input, this function loads that toolbox XML to the workspace,
- * creating category and separator tabs as necessary. This allows the user
- * to be able to edit toolboxes given their XML form. Catches errors from
+ * from file input, if the import mode is for the toolbox, this function loads
+ * that toolbox XML to the workspace, creating category and separator tabs as
+ * necessary. If the import mode is for pre-loaded blocks in the workspace,
+ * this function loads that XML to the workspace to be edited further. This
+ * function switches mode to whatever the import mode is. Catches errors from
  * file reading and prints an error message alerting the user.
  *
  * @param {string} file The path for the file to be imported into the workspace.
  * Should contain valid toolbox XML.
+ * @param {!string} importMode The mode corresponding to the type of file the
+ *    user is importing (FactoryController.MODE_TOOLBOX or
+ *    FactoryController.MODE_PRELOAD).
  */
- // UPDATE COMMENTS
-FactoryController.prototype.importFile = function(file, isToolbox) {
+FactoryController.prototype.importFile = function(file, importMode) {
   // Exit if cancelled.
   if (!file) {
     return;
@@ -566,12 +604,17 @@ FactoryController.prototype.importFile = function(file, isToolbox) {
     // Print error message if fail.
     try {
       var tree = Blockly.Xml.textToDom(reader.result);
-      if (isToolbox) {
+      if (importMode == FactoryController.MODE_TOOLBOX) {
+        // Switch mode and import toolbox XML.
         controller.setMode(FactoryController.MODE_TOOLBOX);
         controller.importToolboxFromTree_(tree);
-      } else {
+      } else if (importMode == FactoryController.MODE_PRELOAD) {
+        // Switch mode and import pre-loaded workspace XML.
         controller.setMode(FactoryController.MODE_PRELOAD);
         controller.importPreloadFromTree_(tree);
+      } else {
+        // Throw error if invalid mode.
+        throw new Error("Unknown import mode: " + importMode);
       }
     } catch(e) {
       alert('Cannot load XML from file.');
@@ -579,14 +622,14 @@ FactoryController.prototype.importFile = function(file, isToolbox) {
     }
   }
 
-  // Read the file.
+  // Read the file asynchronously.
   reader.readAsText(file);
 };
 
 /**
  * Given a XML DOM tree, loads it into the toolbox editing area so that the
  * user can continue editing their work. Assumes that tree is in valid toolbox
- * XML format.
+ * XML format. Assumes that the mode is MODE_TOOLBOX.
  * @private
  *
  * @param {!Element} tree XML tree to be loaded to toolbox editing area.
@@ -651,12 +694,18 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
   this.updatePreview();
 };
 
+/**
+ * Given a XML DOM tree, loads it into the pre-loaded workspace editing area.
+ * Assumes that tree is in valid XML format and that the selected mode is
+ * MODE_PRELOAD.
+ *
+ * @param {!Element} tree XML tree to be loaded to pre-loaded block editing
+ *    area.
+ */
 FactoryController.prototype.importPreloadFromTree_ = function(tree) {
   this.clearAndLoadXml_(tree);
   this.model.savePreloadXml(tree);
-  this.updatePreview(); //assuming that updatePreview still calls domToWorkspace regardless of mode
-  // this.previewWorkspace.domToWorkspace
-  //     (this.generator.generateWorkspaceXml(tree));
+  this.updatePreview();
 }
 
 /**
@@ -761,8 +810,10 @@ FactoryController.prototype.setMode = function(mode) {
 
   if (mode == FactoryController.MODE_TOOLBOX) {
     // Open the toolbox editing space.
-    this.model.savePreloadXml(this.generator.generateWorkspaceXml
-        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)));
+    document.getElementById('editHelpText').textContent =
+        'Drag blocks into your toolbox:';
+    this.model.savePreloadXml
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
     this.clearAndLoadXml_(this.model.getSelectedXml());
     this.view.disableWorkspace(this.view.shouldDisableWorkspace
         (this.model.getSelected()));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -443,11 +443,15 @@ FactoryController.prototype.loadCategory = function() {
 
   // Copy the standard category in the model.
   var copy = standardCategory.copy();
+
+  // Add the copy in the view.
+  var tab = this.view.addCategoryRow(copy.name, copy.id,
+      !this.model.hasToolbox());
+
+  // Add it to the model.
   this.model.addElementToList(copy);
 
-  // Update the copy in the view.
-  var tab = this.view.addCategoryRow(copy.name, copy.id,
-      this.model.getSelected() == null);
+  // Update the view.
   this.addClickToSwitch(tab, copy.id);
   // Color the category tab in the view.
   if (copy.color) {
@@ -526,6 +530,7 @@ FactoryController.prototype.importFile = function(file) {
       controller.importFromTree_(tree);
     } catch(e) {
       alert('Cannot load XML from file.');
+      console.log(e);
     }
   }
 
@@ -581,8 +586,13 @@ FactoryController.prototype.importFromTree_ = function(tree) {
         this.convertShadowBlocks_();
 
         // Set category color.
-        if (item.color) {
-          category.changeColor(item.color);
+        if (item.getAttribute('colour')) {
+          category.changeColor(item.getAttribute('colour'));
+          this.view.setBorderColor(category.id, category.color);
+        }
+        // Set any custom tags.
+        if (item.getAttribute('custom')) {
+          this.model.addCustomTag(category, item.getAttribute('custom'));
         }
       } else {
         // If the element is a separator, add the separator and switch to it.
@@ -591,7 +601,8 @@ FactoryController.prototype.importFromTree_ = function(tree) {
       }
     }
   }
-
+  this.view.updateState(this.model.getIndexByElementId
+      (this.model.getSelectedId()), this.model.getSelected());
   this.updatePreview();
 };
 
@@ -603,6 +614,7 @@ FactoryController.prototype.clear = function() {
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
   this.view.addEmptyCategoryMessage();
+  this.view.updateState(-1, null);
   this.toolboxWorkspace.clear();
   this.toolboxWorkspace.clearUndo();
   this.updatePreview();

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -57,6 +57,13 @@ FactoryController = function(toolboxWorkspace, previewWorkspace) {
   this.selectedMode = FactoryController.MODE_TOOLBOX;
 };
 
+// Toolbox editing mode. Changes the user makes to the workspace updates the
+// toolbox.
+FactoryController.MODE_TOOLBOX = 'toolbox';
+// Pre-loaded workspace editing mode. Changes the user makes to the workspace
+// udpates the pre-loaded blocks.
+FactoryController.MODE_PRELOAD = 'preload';
+
 /**
  * Currently prompts the user for a name, checking that it's valid (not used
  * before), and then creates a tab and switches to it.
@@ -725,10 +732,11 @@ FactoryController.prototype.setMode = function(mode) {
   // Update selected tab.
   this.selectedMode = mode;
 
+  // Update help text above workspace.
+  this.view.updateHelpText(mode);
+
   if (mode == FactoryController.MODE_TOOLBOX) {
     // Open the toolbox editing space.
-    document.getElementById('editHelpText').textContent =
-        'Drag blocks into your toolbox:';
     this.model.savePreloadXml(this.generator.generateWorkspaceXml
         (this.toolboxWorkspace));
     this.clearAndLoadXml_(this.model.getSelectedXml());
@@ -736,8 +744,6 @@ FactoryController.prototype.setMode = function(mode) {
         (this.model.getSelected()));
   } else {
     // Open the pre-loaded workspace editing space.
-    document.getElementById('editHelpText').textContent =
-        'Drag blocks into your pre-loaded workspace:';
     if (this.model.getSelected()) {
       this.model.getSelected().saveFromWorkspace(this.toolboxWorkspace);
     }
@@ -760,10 +766,3 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
   this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
       (this.toolboxWorkspace.getAllBlocks()));
 }
-
-// Toolbox editing mode. Changes the user makes to the workspace updates the
-// toolbox.
-FactoryController.MODE_TOOLBOX = 'toolbox';
-// Pre-loaded workspace editing mode. Changes the user makes to the workspace
-// udpates the pre-loaded blocks.
-FactoryController.MODE_PRELOAD = 'preload';

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -369,7 +369,7 @@ FactoryController.prototype.updatePreview = function() {
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
-  } else {
+  } else if (this.selectedMode == FactoryController.MODE_PRELOAD){
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
@@ -426,9 +426,8 @@ FactoryController.prototype.reinjectPreview = function(tree) {
  * currently in use, exits if user presses cancel.
  */
 FactoryController.prototype.changeCategoryName = function() {
-  // Return if no category selected or element a separator.
-  if (!this.model.getSelected() ||
-      this.model.getSelected().type == ListElement.TYPE_SEPARATOR) {
+  // Return if a category is not selected.
+  if (this.model.getSelected().type != ListElement.TYPE_CATEGORY) {
     return;
   }
   // Get new name from user.
@@ -496,9 +495,8 @@ FactoryController.prototype.moveElementToIndex = function(element, newIndex,
  * a valid CSS string.
  */
 FactoryController.prototype.changeSelectedCategoryColor = function(color) {
-  // Return if no category selected or element a separator.
-  if (!this.model.getSelected() ||
-      this.model.getSelected().type == ListElement.TYPE_SEPARATOR) {
+  // Return if category is not selected.
+  if (this.model.getSelected().type != ListElement.TYPE_CATEGORY) {
     return;
   }
   // Change color of selected category.

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -276,24 +276,15 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
  *    FactoryController.MODE_PRELOAD for the pre-loaded workspace configuration)
  */
 FactoryController.prototype.exportFile = function(exportMode) {
+  // Save workspace in current state.
+  this.saveStateFromWorkspace();
   // Generate XML.
   if (exportMode == FactoryController.MODE_TOOLBOX) {
     // Export the toolbox XML.
-    if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
-      // Capture any changes made by user before generating XML if in
-      // toolbox mode.
-      this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
-    }
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateToolboxXml());
   } else if (exportMode == FactoryController.MODE_PRELOAD) {
     // Export the pre-loaded block XML.
-    if (this.selectedMode == FactoryController.MODE_PRELOAD) {
-      // Capture any changes made by user before generating XML if in
-      // preload workspace mode.
-      this.model.savePreloadXml(Blockly.Xml.workspaceToDom
-          (this.toolboxWorkspace));
-    }
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateWorkspaceXml());
   } else {
@@ -319,7 +310,7 @@ FactoryController.prototype.exportFile = function(exportMode) {
  */
 FactoryController.prototype.printConfig = function() {
   // Capture any changes made by user before generating XML.
-  this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+  this.saveStateFromWorkspace();
   // Print XML.
   window.console.log(Blockly.Xml.domToPrettyText
       (this.generator.generateToolboxXml()));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -628,7 +628,7 @@ FactoryController.prototype.importFile = function(file, importMode) {
   reader.onload = function() {
     // Try to parse XML from file and load it into toolbox editing area.
     // Print error message if fail.
-    try {
+    //try {
       var tree = Blockly.Xml.textToDom(reader.result);
       if (importMode == FactoryController.MODE_TOOLBOX) {
         // Switch mode and import toolbox XML.
@@ -723,6 +723,14 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
   this.saveStateFromWorkspace();
   this.updatePreview();
 };
+
+FactoryController.prototype.importPreloadFromTree_ = function(tree) {
+  this.clearAndLoadXml_(tree);
+  this.model.savePreloadXml(tree);
+  this.updatePreview(); //assuming that updatePreview still calls domToWorkspace regardless of mode
+  // this.previewWorkspace.domToWorkspace
+  //     (this.generator.generateWorkspaceXml(tree));
+}
 
 /**
  * Given a XML DOM tree, loads it into the pre-loaded workspace editing area.
@@ -844,6 +852,11 @@ FactoryController.prototype.convertShadowBlocks = function() {
  *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
  */
 FactoryController.prototype.setMode = function(mode) {
+  // No work to change mode that's currently set.
+  if (this.selectedMode == mode) {
+    return;
+  }
+
   // No work to change mode that's currently set.
   if (this.selectedMode == mode) {
     return;

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -291,19 +291,22 @@ FactoryController.prototype.updatePreview = function() {
   // Disable events to stop updatePreview from recursively calling itself
   // through event handlers.
   Blockly.Events.disable();
+
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
     var tree = Blockly.Options.parseToolboxTree
         (this.generator.generateConfigXml(this.toolboxWorkspace));
-    // No categories, creates a simple flyout.
+
     if (tree.getElementsByTagName('category').length == 0) {
+      // No categories, creates a simple flyout.
       if (this.previewWorkspace.toolbox_) {
         this.reinjectPreview(tree); // Switch to simple flyout, more expensive.
       } else {
         this.previewWorkspace.flyout_.show(tree.childNodes);
       }
-    // Uses categories, creates a toolbox.
+
     } else {
+      // Uses categories, creates a toolbox.
       if (!previewWorkspace.toolbox_) {
         this.reinjectPreview(tree); // Create a toolbox, more expensive.
       } else {
@@ -323,6 +326,7 @@ FactoryController.prototype.updatePreview = function() {
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
         (this.toolboxWorkspace), this.previewWorkspace);
   }
+
   // Reenable events.
   Blockly.Events.enable();
 };
@@ -725,7 +729,6 @@ FactoryController.prototype.convertShadowBlocks = function() {
  *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
  */
 FactoryController.prototype.setMode = function(mode) {
-
   // Set tab selection and display appropriate tab.
   this.view.setModeSelection(mode);
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -379,7 +379,7 @@ FactoryController.prototype.saveStateFromWorkspace = function() {
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
     this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
-  } else {
+  } else if (this.selectedMode == FactoryController.MODE_PRELOAD) {
     // If currently editing the pre-loaded workspace.
     this.model.savePreloadXml
         (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -70,12 +70,7 @@ FactoryController.MODE_PRELOAD = 'preload';
  */
 FactoryController.prototype.addCategory = function() {
   // Check if it's the first category added.
-<<<<<<< 6c4523255d10db8d11c441665e26da2dd3319d36
   var isFirstCategory = !this.model.hasElements();
-=======
-  var firstCategory = !this.model.hasToolbox();
-
->>>>>>> Refactored to generate new options object each time input changes
   // Give the option to save blocks if their workspace is not empty and they
   // are creating their first category.
   if (isFirstCategory && this.toolboxWorkspace.getAllBlocks().length > 0) {
@@ -95,14 +90,13 @@ FactoryController.prototype.addCategory = function() {
       this.createCategory(name, true);
       // Set the new category as selected.
       this.model.setSelectedById(this.model.getCategoryIdByName(name));
+      // Allow user to use the default options for injecting with categories.
+      this.allowToSetDefaultOptions();
     }
   }
 
-<<<<<<< 6c4523255d10db8d11c441665e26da2dd3319d36
   // After possibly creating a category, check again if it's the first category.
   isFirstCategory = !this.model.hasElements();
-=======
->>>>>>> Refactored to generate new options object each time input changes
   // Get name from user.
   name = this.promptForNewCategoryName('Enter the name of your new category: ');
   if (!name) {  //Exit if cancelled.
@@ -335,6 +329,9 @@ FactoryController.prototype.exportOptionsFile = function() {
   if (!fileName) {  // If cancelled.
     return;
   }
+  // Generate new options to remove toolbox XML from options object (if
+  // necessary).
+  this.generateNewOptions();
   // TODO(evd2014): Use Regex to prettify JSON generated.
   var data = new Blob([JSON.stringify(this.model.options)],
       {type: 'text/plain'});
@@ -655,25 +652,22 @@ FactoryController.prototype.importFile = function(file, importMode) {
     // Print error message if fail.
     try {
       var tree = Blockly.Xml.textToDom(reader.result);
-
       if (importMode == FactoryController.MODE_TOOLBOX) {
         // Switch mode and import toolbox XML.
         controller.setMode(FactoryController.MODE_TOOLBOX);
         controller.importToolboxFromTree_(tree);
-
       } else if (importMode == FactoryController.MODE_PRELOAD) {
         // Switch mode and import pre-loaded workspace XML.
         controller.setMode(FactoryController.MODE_PRELOAD);
         controller.importPreloadFromTree_(tree);
-
       } else {
         // Throw error if invalid mode.
         throw new Error("Unknown import mode: " + importMode);
       }
-    } catch(e) {
-      alert('Cannot load XML from file.');
-      console.log(e);
-    }
+     } catch(e) {
+       alert('Cannot load XML from file.');
+       console.log(e);
+     }
   }
 
   // Read the file asynchronously.
@@ -981,7 +975,7 @@ FactoryController.prototype.allowToSetDefaultOptions = function() {
       'with categories?')) {
     return;
   }
-  this.view.setCategoryOptions(this.model.hasCategories());
+  this.view.setCategoryOptions(this.model.hasToolbox());
   this.generateNewOptions();
 };
 
@@ -992,20 +986,54 @@ FactoryController.prototype.allowToSetDefaultOptions = function() {
  */
 FactoryController.prototype.generateNewOptions = function() {
   var optionsObj = new Object(null);
-  var options = document.getElementById('workspace_options').children;
 
-  for (var i = 0, option; option = options[i]; i++) {
-    if (option.name && option.getAttribute('name') != 'grid' &&
-        option.getAttribute('name') !='zoom') {
-      this.addOption_(option, optionsObj);
-    }
-  }
+  // Add all standard options to the options object.
+  optionsObj['collapse'] = this.getOptionValue_('option_collapse_checkbox',
+      'checkbox');
+  optionsObj['comments'] = this.getOptionValue_('option_comments_checkbox',
+      'checkbox');
+  optionsObj['css'] = this.getOptionValue_('option_css_checkbox', 'checkbox');
+  optionsObj['disable'] = this.getOptionValue_('option_disable_checkbox',
+      'checkbox');
+  optionsObj['maxBlocks'] = this.getOptionValue_('option_maxBlocks_text',
+      'number');
+  optionsObj['media'] = this.getOptionValue_('option_media_text', 'text');
+  optionsObj['readOnly'] = this.getOptionValue_('option_readOnly_checkbox',
+      'checkbox');
+  optionsObj['rtl'] = this.getOptionValue_('option_rtl_checkbox', 'checkbox');
+  optionsObj['scrollbars'] = this.getOptionValue_('option_scrollbars_checkbox',
+      'checkbox');
+  optionsObj['sounds'] = this.getOptionValue_('option_sounds_checkbox',
+      'checkbox');
+  optionsObj['trashcan'] = this.getOptionValue_('option_trashcan_checkbox',
+      'checkbox');
 
+  // If using a grid, add all grid options.
   if (document.getElementById('option_grid_checkbox').checked) {
-    optionsObj['grid'] = this.generateSubOptionsObj_('grid_options');
+    var grid = new Object(null);
+    grid['spacing'] = this.getOptionValue_('gridOption_spacing_text', 'number');
+    grid['length'] = this.getOptionValue_('gridOption_length_text', 'number');
+    grid['colour'] = this.getOptionValue_('gridOption_colour_text', 'text');
+    grid['snap'] = this.getOptionValue_('gridOption_snap_checkbox', 'checkbox');
+    optionsObj['grid'] = grid;
   }
+
+  // If using zoom, add all zoom options.
   if (document.getElementById('option_zoom_checkbox').checked) {
-    optionsObj['zoom'] = this.generateSubOptionsObj_('zoom_options');
+    var zoom = new Object(null);
+    zoom['controls'] = this.getOptionValue_('zoomOption_controls_checkbox',
+        'checkbox');
+    zoom['wheel'] = this.getOptionValue_('zoomOption_wheel_checkbox',
+        'checkbox');
+    zoom['startScale'] = this.getOptionValue_('zoomOption_startScale_text',
+        'number');
+    zoom['maxScale'] = this.getOptionValue_('zoomOption_maxScale_text',
+        'number');
+    zoom['minScale'] = this.getOptionValue_('zoomOption_minScale_text',
+        'number');
+    zoom['scaleSpeed'] = this.getOptionValue_('zoomOption_scaleSpeed_text',
+        'number');
+    optionsObj['zoom'] = zoom;
   }
 
   this.model.setOptions(optionsObj);
@@ -1015,46 +1043,22 @@ FactoryController.prototype.generateNewOptions = function() {
 };
 
 /**
- * Generates a suboptions object given the name of the div where the suboption
- * input fields are located.
+ * Given the name of an input DOM element and the type of input field, returns
+ * the value that should be recorded in the options object.
  * @private
  *
- * @param {!string} optionsDivName Name of the div element where suboption
- *    input fields are.
- * @return {!Object} Suboptions object populated with all the attributes in
- *    the suboptions div.
+ * @param {!string} optionId The ID of the input DOM element for an option.
+ * @param {!string} type The type of input for that DOM element ('checkbox',
+ *    'number', or 'text').
  */
-FactoryController.prototype.generateSubOptionsObj_ = function(optionsDivName) {
-  var subOptions = document.getElementById(optionsDivName).children;
-  var subOptionsObj = new Object(null);
-
-  for (var i = 0, option; option = subOptions[i]; i++) {
-    if (option.name) {
-      this.addOption_(option, subOptionsObj);
-    }
-  }
-  return subOptionsObj;
-};
-
-/**
- * Given an input DOM element and an options object, adds the attribute for
- * that input field to the options object. Checkboxes, text input fields, and
- * text input fields for numbers are all treated differently.
- * @private
- *
- * @param {!Element} option DOM input element for the option.
- * @param {!Object} optionsObj Options object to add the attribute to.
- */
-FactoryController.prototype.addOption_ = function(option, optionsObj) {
-  if (option.type == 'checkbox') {
-    optionsObj[option.name] = option.checked;
-
-  } else if (option.type == 'text') {
-    var value = option.value;
-    if (type = option.getAttribute('custom') == 'number') {
-      value = parseInt(value);
-    }
-    optionsObj[option.name] = value;
+FactoryController.prototype.getOptionValue_ = function(optionId, type) {
+  var option = document.getElementById(optionId);
+  if (type == 'checkbox') {
+    return option.checked;
+  } else  if (type == 'number') {
+    return parseInt(option.value);
+  } else if (type == 'text') {
+    return option.value;
   }
 };
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -400,19 +400,20 @@ FactoryController.prototype.saveStateFromWorkspace = function() {
  */
 FactoryController.prototype.reinjectPreview = function(tree) {
   this.previewWorkspace.dispose();
-  previewToolbox = Blockly.Xml.domToPrettyText(tree);
-  this.previewWorkspace = Blockly.inject('preview_blocks',
-    {grid:
-      {spacing: 25,
-       length: 3,
-       colour: '#ccc',
-       snap: true},
-     media: '../../../media/',
-     toolbox: previewToolbox,
-     zoom:
-       {controls: true,
-        wheel: true}
-    });
+  this.model.setOption('toolbox', Blockly.Xml.domToPrettyText(tree));
+  this.previewWorkspace = Blockly.inject('preview_blocks', this.model.options);
+   // this.previewWorkspace = Blockly.inject('preview_blocks',
+   //   {grid:
+   //     {spacing: 25,
+   //      length: 3,
+   //      colour: '#ccc',
+   //      snap: true},
+   //    media: '../../../media/',
+   //    toolbox: previewToolbox,
+   //    zoom:
+   //      {controls: true,
+   //       wheel: true}
+   //   });
 };
 
 /**
@@ -909,6 +910,21 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
       (this.toolboxWorkspace.getAllBlocks()));
 }
 
-FactoryController.prototype.setOptions = function(type, value) {
-  this.model.setOptions(type, value);
+FactoryController.prototype.setOptions = function(type, value,
+    opt_parentOption) {
+  if (!opt_parentOption) {
+    this.model.setOption(type, value);
+  } else {
+    console.log("calling suboption for " + opt_parentOption);
+    this.model.setSubOption(opt_parentOption, type, value);
+  }
+  this.reinjectPreview(Blockly.Options.parseToolboxTree
+        (this.generator.generateToolboxXml()));
 };
+
+FactoryController.prototype.removeOption = function(type) {
+  this.model.removeOption(type);
+  this.reinjectPreview(Blockly.Options.parseToolboxTree
+        (this.generator.generateToolboxXml()));
+}
+

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -151,30 +151,41 @@ FactoryController.prototype.removeElement = function() {
   if (!this.model.getSelected()) {
     return;
   }
+
   // Check if user wants to remove current category.
   var check = confirm('Are you sure you want to delete the currently selected '
         + this.model.getSelected().type + '?');
   if (!check) { // If cancelled, exit.
     return;
   }
+
   var selectedId = this.model.getSelectedId();
   var selectedIndex = this.model.getIndexByElementId(selectedId);
   // Delete element visually.
   this.view.deleteElementRow(selectedId, selectedIndex);
   // Delete element in model.
   this.model.deleteElementFromList(selectedIndex);
+
   // Find next logical element to switch to.
   var next = this.model.getElementByIndex(selectedIndex);
   if (!next && this.model.hasToolbox()) {
     next = this.model.getElementByIndex(selectedIndex - 1);
   }
   var nextId = next ? next.id : null;
+
   // Open next element.
   this.clearAndLoadElement(nextId);
+
+  // If no element to switch to, display message, clear the workspace, and
+  // set a default selected element not in toolbox list in the model.
   if (!nextId) {
     alert('You currently have no categories or separators. All your blocks' +
         ' will be displayed in a single flyout.');
+    this.toolboxWorkspace.clear();
+    this.toolboxWorkspace.clearUndo();
+    this.model.setDefaultSelected();
   }
+
   // Update preview.
   this.updatePreview();
 };
@@ -235,17 +246,21 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
     this.view.disableWorkspace(false);
   }
 
-  // Set next category.
-  this.model.setSelectedById(id);
+  // If switching to another category, set category selection in the model and
+  // view.
+  if (id != null) {
+    // Set next category.
+    this.model.setSelectedById(id);
 
-  // Clears workspace and loads next category.
-  this.clearAndLoadXml_(this.model.getSelectedXml());
+    // Clears workspace and loads next category.
+    this.clearAndLoadXml_(this.model.getSelectedXml());
 
-  // Selects the next tab.
-  this.view.setCategoryTabSelection(id, true);
+    // Selects the next tab.
+    this.view.setCategoryTabSelection(id, true);
 
-  // Order blocks as if shown in the flyout.
-  this.toolboxWorkspace.cleanUp_();
+    // Order blocks as if shown in the flyout.
+    this.toolboxWorkspace.cleanUp_();
+  }
 
   // Update category editing buttons.
   this.view.updateState(this.model.getIndexByElementId
@@ -710,9 +725,10 @@ FactoryController.prototype.importPreloadFromTree_ = function(tree) {
 
 /**
  * Clears the toolbox editing area completely, deleting all categories and all
- * blocks in the model and view.
+ * blocks in the model and view. Sets the mode to toolbox mode.
  */
-FactoryController.prototype.clear = function() {
+FactoryController.prototype.clearToolbox = function() {
+  this.setMode(FactoryController.MODE_TOOLBOX);
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
   this.view.addEmptyCategoryMessage();

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -348,6 +348,7 @@ FactoryController.prototype.updatePreview = function() {
 
     } else {
       // Uses categories, creates a toolbox.
+
       if (!previewWorkspace.toolbox_) {
         this.reinjectPreview(tree); // Create a toolbox, more expensive.
       } else {
@@ -812,6 +813,7 @@ FactoryController.prototype.convertShadowBlocks = function() {
   }
 };
 
+<<<<<<< b52dd61f1b76c06b816c73ff4dccfce9fa9fd74f
 /**
  * Sets the currently selected mode that determines what the toolbox workspace
  * is being used to edit. Updates the view and then saves and loads XML

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -278,6 +278,7 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
 FactoryController.prototype.exportFile = function(exportMode) {
   // Save workspace in current state.
   this.saveStateFromWorkspace();
+
   // Generate XML.
   if (exportMode == FactoryController.MODE_TOOLBOX) {
     // Export the toolbox XML.

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -372,12 +372,22 @@ FactoryController.prototype.updatePreview = function() {
     // blocks don't get cleared when updating preview from event listeners while
     // switching modes.
     this.previewWorkspace.clear();
+<<<<<<< 8d894a801cfe834cbaa1a468d1430524e90e4527
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
   } else if (this.selectedMode == FactoryController.MODE_PRELOAD){
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
+=======
+    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
+        (this.model.getPreloadXml()), this.previewWorkspace);
+  } else {
+    // If currently editing the pre-loaded workspace.
+    this.previewWorkspace.clear();
+    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)),
+>>>>>>> Have basic import options working
         this.previewWorkspace);
   }
 
@@ -623,7 +633,12 @@ FactoryController.prototype.addSeparator = function() {
  *    user is importing (FactoryController.MODE_TOOLBOX or
  *    FactoryController.MODE_PRELOAD).
  */
+<<<<<<< 8d894a801cfe834cbaa1a468d1430524e90e4527
 FactoryController.prototype.importFile = function(file, importMode) {
+=======
+ // UPDATE COMMENTS
+FactoryController.prototype.importFile = function(file, isToolbox) {
+>>>>>>> Have basic import options working
   // Exit if cancelled.
   if (!file) {
     return;
@@ -634,8 +649,9 @@ FactoryController.prototype.importFile = function(file, importMode) {
   reader.onload = function() {
     // Try to parse XML from file and load it into toolbox editing area.
     // Print error message if fail.
-    try {
+    //try {
       var tree = Blockly.Xml.textToDom(reader.result);
+<<<<<<< 8d894a801cfe834cbaa1a468d1430524e90e4527
       if (importMode == FactoryController.MODE_TOOLBOX) {
         // Switch mode and import toolbox XML.
         controller.setMode(FactoryController.MODE_TOOLBOX);
@@ -652,6 +668,20 @@ FactoryController.prototype.importFile = function(file, importMode) {
       alert('Cannot load XML from file.');
       console.log(e);
     }
+=======
+      if (isToolbox) {
+        controller.setMode(FactoryController.MODE_TOOLBOX);
+        controller.importToolboxFromTree_(tree);
+      } else {
+        controller.setMode(FactoryController.MODE_PRELOAD);
+        controller.importPreloadFromTree_(tree);
+      }
+    // } catch(e) {
+    //   alert('Cannot load XML from file.');
+    //   console.log(e);
+    //   console.log(e.lineno);
+    // }
+>>>>>>> Have basic import options working
   }
 
   // Read the file asynchronously.
@@ -728,6 +758,14 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
 
   this.updatePreview();
 };
+
+FactoryController.prototype.importPreloadFromTree_ = function(tree) {
+  this.clearAndLoadXml_(tree);
+  this.model.savePreloadXml(tree);
+  this.updatePreview(); //assuming that updatePreview still calls domToWorkspace regardless of mode
+  // this.previewWorkspace.domToWorkspace
+  //     (this.generator.generateWorkspaceXml(tree));
+}
 
 /**
  * Given a XML DOM tree, loads it into the pre-loaded workspace editing area.
@@ -850,10 +888,15 @@ FactoryController.prototype.setMode = function(mode) {
 
   if (mode == FactoryController.MODE_TOOLBOX) {
     // Open the toolbox editing space.
+<<<<<<< 8d894a801cfe834cbaa1a468d1430524e90e4527
     document.getElementById('editHelpText').textContent =
         'Drag blocks into your toolbox:';
     this.model.savePreloadXml
         (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+=======
+    this.model.savePreloadXml(this.generator.generateWorkspaceXml
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)));
+>>>>>>> Have basic import options working
     this.clearAndLoadXml_(this.model.getSelectedXml());
     this.view.disableWorkspace(this.view.shouldDisableWorkspace
         (this.model.getSelected()));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -70,13 +70,19 @@ FactoryController.MODE_PRELOAD = 'preload';
  */
 FactoryController.prototype.addCategory = function() {
   // Check if it's the first category added.
+<<<<<<< 6c4523255d10db8d11c441665e26da2dd3319d36
   var isFirstCategory = !this.model.hasElements();
+=======
+  var firstCategory = !this.model.hasToolbox();
+
+>>>>>>> Refactored to generate new options object each time input changes
   // Give the option to save blocks if their workspace is not empty and they
   // are creating their first category.
   if (isFirstCategory && this.toolboxWorkspace.getAllBlocks().length > 0) {
     var confirmCreate = confirm('Do you want to save your work in another '
         + 'category? If you don\'t, the blocks in your workspace will be ' +
         'deleted.');
+
     // Create a new category for current blocks.
     if (confirmCreate) {
       var name = prompt('Enter the name of the category for your ' +
@@ -84,18 +90,19 @@ FactoryController.prototype.addCategory = function() {
       if (!name) {  // Exit if cancelled.
         return;
       }
+
       // Create the new category.
       this.createCategory(name, true);
-      // Allow the user to use the default options for injecting the workspace
-      // when there are categories.
-      this.allowToSetDefaultOptions();
       // Set the new category as selected.
       this.model.setSelectedById(this.model.getCategoryIdByName(name));
     }
   }
 
+<<<<<<< 6c4523255d10db8d11c441665e26da2dd3319d36
   // After possibly creating a category, check again if it's the first category.
   isFirstCategory = !this.model.hasElements();
+=======
+>>>>>>> Refactored to generate new options object each time input changes
   // Get name from user.
   name = this.promptForNewCategoryName('Enter the name of your new category: ');
   if (!name) {  //Exit if cancelled.
@@ -105,6 +112,7 @@ FactoryController.prototype.addCategory = function() {
   this.createCategory(name, isFirstCategory);
   // Switch to category.
   this.switchElement(this.model.getCategoryIdByName(name));
+
    // Allow the user to use the default options for injecting the workspace
   // when there are categories if adding the first category.
   if (firstCategory) {
@@ -426,7 +434,7 @@ FactoryController.prototype.saveStateFromWorkspace = function() {
  */
 FactoryController.prototype.reinjectPreview = function(tree) {
   this.previewWorkspace.dispose();
-  this.model.setOption('toolbox', Blockly.Xml.domToPrettyText(tree));
+  this.model.setOptionsAttribute('toolbox', Blockly.Xml.domToPrettyText(tree));
   this.previewWorkspace = Blockly.inject('preview_blocks', this.model.options);
 };
 
@@ -640,20 +648,24 @@ FactoryController.prototype.importFile = function(file, importMode) {
   }
 
   var reader = new FileReader();
+
   // To be executed when the reader has read the file.
   reader.onload = function() {
     // Try to parse XML from file and load it into toolbox editing area.
     // Print error message if fail.
     try {
       var tree = Blockly.Xml.textToDom(reader.result);
+
       if (importMode == FactoryController.MODE_TOOLBOX) {
         // Switch mode and import toolbox XML.
         controller.setMode(FactoryController.MODE_TOOLBOX);
         controller.importToolboxFromTree_(tree);
+
       } else if (importMode == FactoryController.MODE_PRELOAD) {
         // Switch mode and import pre-loaded workspace XML.
         controller.setMode(FactoryController.MODE_PRELOAD);
         controller.importPreloadFromTree_(tree);
+
       } else {
         // Throw error if invalid mode.
         throw new Error("Unknown import mode: " + importMode);
@@ -693,9 +705,6 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
     // Add message to denote empty category.
     this.view.addEmptyCategoryMessage();
 
-    // Allow the user to set the default configuration options for a single
-    // flyout.
-    this.allowToSetDefaultOptions();
   } else {
     // Categories/separators present.
     for (var i = 0, item; item = tree.children[i]; i++) {
@@ -735,10 +744,6 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
         this.switchElement(this.model.getElementByIndex(i).id);
       }
     }
-
-    // Allow the user to set the default configuration options for using
-    // categories.
-    this.allowToSetDefaultOptions();
   }
   this.view.updateState(this.model.getIndexByElementId
       (this.model.getSelectedId()), this.model.getSelected());
@@ -746,6 +751,10 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
   this.saveStateFromWorkspace();
 
   this.saveStateFromWorkspace();
+  // Allow the user to set default configuration options for a single flyout
+  // or multiple categories.
+  this.allowToSetDefaultOptions();
+
   this.updatePreview();
 };
 
@@ -795,7 +804,8 @@ FactoryController.prototype.importPreloadFromTree_ = function(tree) {
 
 /**
  * Clears the toolbox editing area completely, deleting all categories and all
- * blocks in the model and view. Sets the mode to toolbox mode.
+ * blocks in the model and view. Sets the mode to toolbox mode. Tied to "Clear
+ * Toolbox" button.
  */
 FactoryController.prototype.clearToolbox = function() {
   this.setMode(FactoryController.MODE_TOOLBOX);
@@ -940,43 +950,6 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
   Blockly.Xml.domToWorkspace(xml, this.toolboxWorkspace);
   this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
       (this.toolboxWorkspace.getAllBlocks()));
-}
-
-/**
- * Sets an attribute in the options object in the model of type with the value
- * 'value'. Optional parent option if the attribute should be an attribute
- * of an object inside of the options object (grid or zoom). Updates the
- * preview workspace after adding.
- *
- * @param {!string} type The name of the attribute to set in the options object
- *    (or an object inside of options).
- * @param {Object} value The value of the attribute called type.
- * @param {!string} opt_parentOption Optional attribute inside of the options
- *    object to which the new attribute should be added. Must have an object
- *    as a value.
- */
-FactoryController.prototype.setOptionAndUpdate = function(type, value,
-    opt_parentOption) {
-  if (!opt_parentOption) {
-    this.model.setOption(type, value);
-  } else {
-    this.model.setSubOption(opt_parentOption, type, value);
-  }
-  this.reinjectPreview(Blockly.Options.parseToolboxTree
-        (this.generator.generateToolboxXml()));
-};
-
-/**
- * Removes an attribute 'type' from the options object and updates the preview
- * workspace.
- *
- * @param {!string} type The name of the attribute in the options objec to
- *    remove.
- */
-FactoryController.prototype.removeOption = function(type) {
-  this.model.removeOption(type);
-  this.reinjectPreview(Blockly.Options.parseToolboxTree
-        (this.generator.generateToolboxXml()));
 };
 
 /**
@@ -985,10 +958,9 @@ FactoryController.prototype.removeOption = function(type) {
  * present.
  */
 FactoryController.prototype.setStandardOptionsAndUpdate = function() {
-  this.setBaseOptions();
-  this.setCategoryOptions();
-  this.reinjectPreview(Blockly.Options.parseToolboxTree
-        (this.generator.generateToolboxXml()));
+  this.view.setBaseOptions();
+  this.view.setCategoryOptions(this.model.hasToolbox());
+  this.generateNewOptions();
  };
 
 /**
@@ -1009,115 +981,80 @@ FactoryController.prototype.allowToSetDefaultOptions = function() {
       'with categories?')) {
     return;
   }
-  this.setCategoryOptions();
-  this.reinjectPreview(Blockly.Options.parseToolboxTree
-        (this.generator.generateToolboxXml()));
+  this.view.setCategoryOptions(this.model.hasCategories());
+  this.generateNewOptions();
 };
 
 /**
- * Sets the basic options that are not dependent on if there are categories
- * or a single flyout of blocks. Updates checkboxes and text fields and the
- * model, but not the preview workspace.
+ * Generates a new options object for injecting a Blockly workspace based
+ * on user input. Should be called every time a change has been made to
+ * an input field. Updates the model and reinjects the preview workspace.
  */
-FactoryController.prototype.setBaseOptions = function() {
-  this.model.setOption('css', true);
-  document.getElementById('css_checkbox').checked = true;
-  this.model.setOption('maxBlocks', Infinity);
-  document.getElementById('maxBlocks_text').value = Infinity;
-  this.model.setOption('media',
-      'https://blockly-demo.appspot.com/static/media/');
-  document.getElementById('media_text').value =
-      'https://blockly-demo.appspot.com/static/media/';
-  this.model.setOption('readOnly', false);
-  document.getElementById('readOnly_checkbox').checked = false;
-  this.model.setOption('rtl', false);
-  document.getElementById('rtl_checkbox').checked = false;
-  this.model.setOption('sounds', true);
-  document.getElementById('sounds_checkbox').checked = true;
-};
+FactoryController.prototype.generateNewOptions = function() {
+  var optionsObj = new Object(null);
+  var options = document.getElementById('workspace_options').children;
 
-/**
- * Updates category specific options depending on if there are categories
- * currently present. Updates checkboxes and text fields and the model, but
- * not the preview workspace.
- */
-FactoryController.prototype.setCategoryOptions = function() {
-  var hasCategories = this.model.hasToolbox();
-  this.model.setOption('collapse', hasCategories);
-  document.getElementById('collapse_checkbox').checked = hasCategories;
-  this.model.setOption('comments', hasCategories);
-  document.getElementById('comments_checkbox').checked = hasCategories;
-  this.model.setOption('disable', hasCategories);
-  document.getElementById('disable_checkbox').checked = hasCategories;
-  this.model.setOption('scrollbars', hasCategories);
-  document.getElementById('scrollbars_checkbox').checked = hasCategories;
-  this.model.setOption('trashcan', hasCategories);
-  document.getElementById('trashcan_checkbox').checked = hasCategories;
-};
-
-/**
- * Applies all suboptions of an object within the options object. Should
- * be called when the 'grid' or 'zoom' boxes are checked.
- *
- * @param {!string} name The name of the object within the options object
- *    where the suboptions should be added.
- * @param {!Array<!Element>} options The DOM elements for the suboptions that
- *    should be applied to the object within the options object.
- */
-FactoryController.prototype.applySubOptions = function(name, options) {
   for (var i = 0, option; option = options[i]; i++) {
-    if (option.type == 'checkbox') {
-      this.setOptionAndUpdate(option.name, option.checked, name);
-    } else if (option.type == 'text') {
-      var value = option.value;
-      if (type = option.getAttribute('custom') == 'number') {
-        value = parseInt(value);
-      }
-      this.setOptionAndUpdate(option.name, value, name);
+    if (option.name && option.getAttribute('name') != 'grid' &&
+        option.getAttribute('name') !='zoom') {
+      this.addOption_(option, optionsObj);
     }
   }
+
+  if (document.getElementById('option_grid_checkbox').checked) {
+    optionsObj['grid'] = this.generateSubOptionsObj_('grid_options');
+  }
+  if (document.getElementById('option_zoom_checkbox').checked) {
+    optionsObj['zoom'] = this.generateSubOptionsObj_('zoom_options');
+  }
+
+  this.model.setOptions(optionsObj);
+
+  this.reinjectPreview(Blockly.Options.parseToolboxTree
+      (this.generator.generateToolboxXml()));
 };
 
 /**
- * Adds event listeners for a checkbox or text input field associated
- * with the options object. The input can modify a top-level attribute within
- * the options object or an attribute of an object inside the options object
- * (with the name opt_parentName).
+ * Generates a suboptions object given the name of the div where the suboption
+ * input fields are located.
+ * @private
  *
- * @param {!Element} option The option input to add the event listener to.
- * @param {string} opt_parentName Optional name of the object inside of the
- *    options object that the input element should add an attribute to.
+ * @param {!string} optionsDivName Name of the div element where suboption
+ *    input fields are.
+ * @return {!Object} Suboptions object populated with all the attributes in
+ *    the suboptions div.
  */
-FactoryController.prototype.addOptionsListener = function (option,
-    opt_parentName) {
-  // Ensure only adding an event listener to a valid input element.
-  if (!option.name) {
-    return;
+FactoryController.prototype.generateSubOptionsObj_ = function(optionsDivName) {
+  var subOptions = document.getElementById(optionsDivName).children;
+  var subOptionsObj = new Object(null);
+
+  for (var i = 0, option; option = subOptions[i]; i++) {
+    if (option.name) {
+      this.addOption_(option, subOptionsObj);
+    }
   }
-  var name = option.name;
-  var id = option.id;
+  return subOptionsObj;
+};
+
+/**
+ * Given an input DOM element and an options object, adds the attribute for
+ * that input field to the options object. Checkboxes, text input fields, and
+ * text input fields for numbers are all treated differently.
+ * @private
+ *
+ * @param {!Element} option DOM input element for the option.
+ * @param {!Object} optionsObj Options object to add the attribute to.
+ */
+FactoryController.prototype.addOption_ = function(option, optionsObj) {
   if (option.type == 'checkbox') {
-    // If adding an event listener for a checkbox.
-    option.addEventListener('change', function(optionName, optionId) {
-      return function() {
-        var checked = document.getElementById(optionId).checked;
-        controller.setOptionAndUpdate(optionName, checked, opt_parentName);
-      };
-    }(name, id));
-  } else {
-    // If adding an event listener for a text field (representing either a
-    // string or a number, as determined by the custom tag).
-    var type = option.getAttribute('custom');
-    option.addEventListener('change', function(optionName, optionId,
-        optionType) {
-      return function() {
-        var value = document.getElementById(optionId).value
-        if (optionType == 'number') {
-          value = parseInt(value);
-        }
-        controller.setOptionAndUpdate(optionName, value, opt_parentName);
-      };
-    }(name, id, type));
+    optionsObj[option.name] = option.checked;
+
+  } else if (option.type == 'text') {
+    var value = option.value;
+    if (type = option.getAttribute('custom') == 'number') {
+      value = parseInt(value);
+    }
+    optionsObj[option.name] = value;
   }
 };
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -988,51 +988,54 @@ FactoryController.prototype.generateNewOptions = function() {
   var optionsObj = new Object(null);
 
   // Add all standard options to the options object.
-  optionsObj['collapse'] = this.getOptionValue_('option_collapse_checkbox',
-      'checkbox');
-  optionsObj['comments'] = this.getOptionValue_('option_comments_checkbox',
-      'checkbox');
-  optionsObj['css'] = this.getOptionValue_('option_css_checkbox', 'checkbox');
-  optionsObj['disable'] = this.getOptionValue_('option_disable_checkbox',
-      'checkbox');
-  optionsObj['maxBlocks'] = this.getOptionValue_('option_maxBlocks_text',
-      'number');
-  optionsObj['media'] = this.getOptionValue_('option_media_text', 'text');
-  optionsObj['readOnly'] = this.getOptionValue_('option_readOnly_checkbox',
-      'checkbox');
-  optionsObj['rtl'] = this.getOptionValue_('option_rtl_checkbox', 'checkbox');
-  optionsObj['scrollbars'] = this.getOptionValue_('option_scrollbars_checkbox',
-      'checkbox');
-  optionsObj['sounds'] = this.getOptionValue_('option_sounds_checkbox',
-      'checkbox');
-  optionsObj['trashcan'] = this.getOptionValue_('option_trashcan_checkbox',
-      'checkbox');
+  // Use parse int to get numbers from value inputs.
+  optionsObj['collapse'] =
+      document.getElementById('option_collapse_checkbox').checked;
+  optionsObj['comments'] =
+      document.getElementById('option_comments_checkbox').checked;
+  optionsObj['css'] = document.getElementById('option_css_checkbox').checked;
+  optionsObj['disable'] =
+      document.getElementById('option_disable_checkbox').checked;
+  optionsObj['maxBlocks'] =
+      parseInt(document.getElementById('option_maxBlocks_text').value);
+  optionsObj['media'] = document.getElementById('option_media_text').value;
+  optionsObj['readOnly'] =
+      document.getElementById('option_readOnly_checkbox').checked;
+  optionsObj['rtl'] = document.getElementById('option_rtl_checkbox').checked;
+  optionsObj['scrollbars'] =
+      document.getElementById('option_scrollbars_checkbox').checked;
+  optionsObj['sounds'] =
+      document.getElementById('option_sounds_checkbox').checked;
+  optionsObj['trashcan'] =
+      document.getElementById('option_trashcan_checkbox').checked;
 
   // If using a grid, add all grid options.
   if (document.getElementById('option_grid_checkbox').checked) {
     var grid = new Object(null);
-    grid['spacing'] = this.getOptionValue_('gridOption_spacing_text', 'number');
-    grid['length'] = this.getOptionValue_('gridOption_length_text', 'number');
-    grid['colour'] = this.getOptionValue_('gridOption_colour_text', 'text');
-    grid['snap'] = this.getOptionValue_('gridOption_snap_checkbox', 'checkbox');
+    grid['spacing'] =
+        parseInt(document.getElementById('gridOption_spacing_text').value);
+    grid['length'] =
+        parseInt(document.getElementById('gridOption_length_text').value);
+    grid['colour'] = document.getElementById('gridOption_colour_text').value;
+    grid['snap'] = document.getElementById('gridOption_snap_checkbox').checked;
     optionsObj['grid'] = grid;
   }
 
   // If using zoom, add all zoom options.
   if (document.getElementById('option_zoom_checkbox').checked) {
     var zoom = new Object(null);
-    zoom['controls'] = this.getOptionValue_('zoomOption_controls_checkbox',
-        'checkbox');
-    zoom['wheel'] = this.getOptionValue_('zoomOption_wheel_checkbox',
-        'checkbox');
-    zoom['startScale'] = this.getOptionValue_('zoomOption_startScale_text',
-        'number');
-    zoom['maxScale'] = this.getOptionValue_('zoomOption_maxScale_text',
-        'number');
-    zoom['minScale'] = this.getOptionValue_('zoomOption_minScale_text',
-        'number');
-    zoom['scaleSpeed'] = this.getOptionValue_('zoomOption_scaleSpeed_text',
-        'number');
+    zoom['controls'] =
+        document.getElementById('zoomOption_controls_checkbox').checked;
+    zoom['wheel'] =
+        document.getElementById('zoomOption_wheel_checkbox').checked;
+    zoom['startScale'] =
+        parseInt(document.getElementById('zoomOption_startScale_text').value);
+    zoom['maxScale'] =
+        parseInt(document.getElementById('zoomOption_maxScale_text').value);
+    zoom['minScale'] =
+        parseInt(document.getElementById('zoomOption_minScale_text').value);
+    zoom['scaleSpeed'] =
+        parseInt(document.getElementById('zoomOption_scaleSpeed_text').value);
     optionsObj['zoom'] = zoom;
   }
 
@@ -1061,4 +1064,3 @@ FactoryController.prototype.getOptionValue_ = function(optionId, type) {
     return option.value;
   }
 };
-

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -303,6 +303,13 @@ FactoryController.prototype.updatePreview = function() {
         this.previewWorkspace.toolbox_.populate_(tree);
       }
     }
+
+    // Update pre-loaded blocks in the preview workspace to make sure that
+    // blocks don't get cleared when updating preview from event listeners while
+    // switching modes.
+    this.previewWorkspace.clear();
+    Blockly.Xml.domToWorkspace(this.model.getPreloadXml(),
+        this.previewWorkspace);
   } else {
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -383,11 +383,7 @@ FactoryController.prototype.saveStateFromWorkspace = function() {
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
     this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
-<<<<<<< 5c38b1f7f28b9490385f0649e2c7ebd6b2f348f4
   } else if (this.selectedMode == FactoryController.MODE_PRELOAD) {
-=======
-  } else {
->>>>>>> Added saveStateFromWorkspace, changed the names of some variables and methods
     // If currently editing the pre-loaded workspace.
     this.model.savePreloadXml
         (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
@@ -913,3 +909,6 @@ FactoryController.prototype.clearAndLoadXml_ = function(xml) {
       (this.toolboxWorkspace.getAllBlocks()));
 }
 
+FactoryController.prototype.setOptions = function(type, value) {
+  this.model.setOptions(type, value);
+};

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -70,10 +70,10 @@ FactoryController.MODE_PRELOAD = 'preload';
  */
 FactoryController.prototype.addCategory = function() {
   // Check if it's the first category added.
-  var firstCategory = !this.model.hasToolbox();
+  var isFirstCategory = !this.model.hasElements();
   // Give the option to save blocks if their workspace is not empty and they
   // are creating their first category.
-  if (firstCategory && this.toolboxWorkspace.getAllBlocks().length > 0) {
+  if (isFirstCategory && this.toolboxWorkspace.getAllBlocks().length > 0) {
     var confirmCreate = confirm('Do you want to save your work in another '
         + 'category? If you don\'t, the blocks in your workspace will be ' +
         'deleted.');
@@ -89,14 +89,14 @@ FactoryController.prototype.addCategory = function() {
     }
   }
   // After possibly creating a category, check again if it's the first category.
-  firstCategory = !this.model.hasToolbox();
+  isFirstCategory = !this.model.hasElements();
   // Get name from user.
   name = this.promptForNewCategoryName('Enter the name of your new category: ');
   if (!name) {  //Exit if cancelled.
     return;
   }
   // Create category.
-  this.createCategory(name, firstCategory);
+  this.createCategory(name, isFirstCategory);
   // Switch to category.
   this.switchElement(this.model.getCategoryIdByName(name));
   // Update preview.
@@ -110,15 +110,15 @@ FactoryController.prototype.addCategory = function() {
  *
  * @param {!string} name Name of category being added.
  * @param {!string} id The ID of the category being added.
- * @param {boolean} firstCategory True if it's the first category created,
+ * @param {boolean} isFirstCategory True if it's the first category created,
  * false otherwise.
  */
-FactoryController.prototype.createCategory = function(name, firstCategory) {
+FactoryController.prototype.createCategory = function(name, isFirstCategory) {
   // Create empty category
   var category = new ListElement(ListElement.TYPE_CATEGORY, name);
   this.model.addElementToList(category);
   // Create new category.
-  var tab = this.view.addCategoryRow(name, category.id, firstCategory);
+  var tab = this.view.addCategoryRow(name, category.id, isFirstCategory);
   this.addClickToSwitch(tab, category.id);
 };
 
@@ -168,7 +168,7 @@ FactoryController.prototype.removeElement = function() {
 
   // Find next logical element to switch to.
   var next = this.model.getElementByIndex(selectedIndex);
-  if (!next && this.model.hasToolbox()) {
+  if (!next && this.model.hasElements()) {
     next = this.model.getElementByIndex(selectedIndex - 1);
   }
   var nextId = next ? next.id : null;
@@ -183,7 +183,7 @@ FactoryController.prototype.removeElement = function() {
         ' will be displayed in a single flyout.');
     this.toolboxWorkspace.clear();
     this.toolboxWorkspace.clearUndo();
-    this.model.setDefaultSelected();
+    this.model.createDefaultSelectedIfEmpty();
   }
 
   // Update preview.
@@ -331,7 +331,9 @@ FactoryController.prototype.printConfig = function() {
  * Blockly with reinjectPreview, otherwise just updates without reinjecting.
  * Called whenever a list element is created, removed, or modified and when
  * Blockly move and delete events are fired. Do not call on create events
- * or disabling will cause the user to "drop" their current blocks.
+ * or disabling will cause the user to "drop" their current blocks. Make sure
+ * that no changes have been made to the workspace since updating the model
+ * (if this might be the case, call saveStateFromWorkspace).
  */
 FactoryController.prototype.updatePreview = function() {
   // Disable events to stop updatePreview from recursively calling itself
@@ -340,8 +342,6 @@ FactoryController.prototype.updatePreview = function() {
 
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
-    // Capture any changes made by user before generating XML.
-    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
     // Get toolbox XML.
     var tree = Blockly.Options.parseToolboxTree
         (this.generator.generateToolboxXml());
@@ -372,14 +372,27 @@ FactoryController.prototype.updatePreview = function() {
   } else {
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
-    this.model.savePreloadXml
-        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
   }
 
   // Reenable events.
   Blockly.Events.enable();
+};
+
+/**
+ * Saves the state from the workspace depending on the current mode. Should
+ * be called after making changes to the workspace.
+ */
+FactoryController.prototype.saveStateFromWorkspace = function() {
+  if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
+    // If currently editing the toolbox.
+    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+  } else {
+    // If currently editing the pre-loaded workspace.
+    this.model.savePreloadXml
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+  }
 };
 
 /**
@@ -529,7 +542,7 @@ FactoryController.prototype.loadCategory = function() {
     return;
   }
 
-  var firstCategory = !this.model.hasToolbox();
+  var isFirstCategory = !this.model.hasElements();
   // Copy the standard category in the model.
   var copy = standardCategory.copy();
 
@@ -537,8 +550,7 @@ FactoryController.prototype.loadCategory = function() {
   this.model.addElementToList(copy);
 
   // Update the copy in the view.
-  var tab = this.view.addCategoryRow(copy.name, copy.id, firstCategory);
-
+  var tab = this.view.addCategoryRow(copy.name, copy.id, isFirstCategory);
   this.addClickToSwitch(tab, copy.id);
   // Color the category tab in the view.
   if (copy.color) {
@@ -547,7 +559,9 @@ FactoryController.prototype.loadCategory = function() {
   // Switch to loaded category.
   this.switchElement(copy.id);
   // Convert actual shadow blocks to user-generated shadow blocks.
-  this.convertShadowBlocks();
+  this.convertShadowBlocks_();
+  // Save state from workspace before updating preview.
+  this.saveStateFromWorkspace();
   // Update preview.
   this.updatePreview();
 };
@@ -576,7 +590,7 @@ FactoryController.prototype.isStandardCategoryName = function(name) {
  */
 FactoryController.prototype.addSeparator = function() {
   // Don't allow the user to add a separator if a category has not been created.
-  if (!this.model.hasToolbox()) {
+  if (!this.model.hasElements()) {
     alert('Add a category before adding a separator.');
     return;
   }
@@ -706,6 +720,9 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
   }
   this.view.updateState(this.model.getIndexByElementId
       (this.model.getSelectedId()), this.model.getSelected());
+
+  this.saveStateFromWorkspace();
+
   this.updatePreview();
 };
 
@@ -720,6 +737,7 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
 FactoryController.prototype.importPreloadFromTree_ = function(tree) {
   this.clearAndLoadXml_(tree);
   this.model.savePreloadXml(tree);
+  this.saveStateFromWorkspace();
   this.updatePreview();
 }
 
@@ -735,6 +753,7 @@ FactoryController.prototype.clearToolbox = function() {
   this.view.updateState(-1, null);
   this.toolboxWorkspace.clear();
   this.toolboxWorkspace.clearUndo();
+  this.saveStateFromWorkspace();
   this.updatePreview();
 };
 
@@ -753,6 +772,7 @@ FactoryController.prototype.addShadow = function() {
   }
   this.view.markShadowBlock(Blockly.selected);
   this.model.addShadowBlock(Blockly.selected.id);
+  this.saveStateFromWorkspace();
   this.updatePreview();
 };
 
@@ -769,6 +789,7 @@ FactoryController.prototype.removeShadow = function() {
   }
   this.model.removeShadowBlock(Blockly.selected.id);
   this.view.unmarkShadowBlock(Blockly.selected);
+  this.saveStateFromWorkspace();
   this.updatePreview();
 };
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -53,6 +53,8 @@ FactoryController = function(toolboxWorkspace, previewWorkspace) {
   this.view = new FactoryView();
   // Generates XML for categories.
   this.generator = new FactoryGenerator(this.model);
+  // Tracks which tab is open. Toolbox tab is open when starting.
+  this.selectedTab = FactoryController.TAB_TOOLBOX;
 };
 
 /**
@@ -293,22 +295,28 @@ FactoryController.prototype.updatePreview = function() {
   // Disable events to stop updatePreview from recursively calling itself
   // through event handlers.
   Blockly.Events.disable();
-  var tree = Blockly.Options.parseToolboxTree
-      (this.generator.generateConfigXml(this.toolboxWorkspace));
-  // No categories, creates a simple flyout.
-  if (tree.getElementsByTagName('category').length == 0) {
-    if (this.previewWorkspace.toolbox_) {
-      this.reinjectPreview(tree); // Switch to simple flyout, more expensive.
+  if (this.selectedTab == FactoryController.TAB_TOOLBOX) {
+    var tree = Blockly.Options.parseToolboxTree
+        (this.generator.generateConfigXml(this.toolboxWorkspace));
+    // No categories, creates a simple flyout.
+    if (tree.getElementsByTagName('category').length == 0) {
+      if (this.previewWorkspace.toolbox_) {
+        this.reinjectPreview(tree); // Switch to simple flyout, more expensive.
+      } else {
+        this.previewWorkspace.flyout_.show(tree.childNodes);
+      }
+    // Uses categories, creates a toolbox.
     } else {
-      this.previewWorkspace.flyout_.show(tree.childNodes);
+      if (!previewWorkspace.toolbox_) {
+        this.reinjectPreview(tree); // Create a toolbox, more expensive.
+      } else {
+        this.previewWorkspace.toolbox_.populate_(tree);
+      }
     }
-  // Uses categories, creates a toolbox.
   } else {
-    if (!previewWorkspace.toolbox_) {
-      this.reinjectPreview(tree); // Create a toolbox, more expensive.
-    } else {
-      this.previewWorkspace.toolbox_.populate_(tree);
-    }
+    this.previewWorkspace.clear();
+    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
+        (this.toolboxWorkspace), this.previewWorkspace);
   }
   // Reenable events.
   Blockly.Events.enable();
@@ -702,3 +710,44 @@ FactoryController.prototype.convertShadowBlocks = function() {
     }
   }
 };
+
+FactoryController.prototype.setTab = function(tab) {
+
+  document.getElementById('tab_preload').className = tab == FactoryController.TAB_PRELOAD ?
+      'tabon' : 'taboff';
+  document.getElementById('preload_div').style.display = tab == FactoryController.TAB_PRELOAD ?
+      'block' : 'none';
+  document.getElementById('tab_toolbox').className = tab == FactoryController.TAB_TOOLBOX ?
+      'tabon' : 'taboff';
+  document.getElementById('toolbox_div').style.display = tab == FactoryController.TAB_TOOLBOX ?
+      'block' : 'none';
+
+  this.selectedTab = tab;
+  if (tab == FactoryController.TAB_TOOLBOX) {
+    this.model.savePreloadXml(this.generator.generateWorkspaceXml
+        (this.toolboxWorkspace));
+    if (this.model.hasToolbox()) {
+      Blockly.Xml.clearAndLoadElement(this.model.getSelectedId());
+    } else {
+      this.toolboxWorkspace.clear();
+      Blockly.Xml.domToWorkspace(this.model.getSelectedXml(), this.toolboxWorkspace);
+      this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
+          (this.toolboxWorkspace.getAllBlocks()));
+    }
+  } else {
+    if (this.model.getSelected()) {
+      console.log('saved');
+      this.model.getSelected().saveFromWorkspace(this.toolboxWorkspace);
+      console.log(this.model.getSelectedXml());
+    }
+    this.toolboxWorkspace.clear();
+    this.toolboxWorkspace.clearUndo();
+    Blockly.Xml.domToWorkspace(this.model.getPreloadXml(),
+        this.toolboxWorkspace);
+    this.view.markShadowBlocks(this.model.getShadowBlocksInWorkspace
+        (this.toolboxWorkspace.getAllBlocks()));
+  }
+};
+
+FactoryController.TAB_TOOLBOX = 'toolbox';
+FactoryController.TAB_PRELOAD = 'preload';

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -252,7 +252,6 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
     // Set next category.
     this.model.setSelectedById(id);
 
-<<<<<<< f68f7c4a490dfb2ccc0db7b8f44930dc316ee38b
     // Clears workspace and loads next category.
     this.clearAndLoadXml_(this.model.getSelectedXml());
 
@@ -262,16 +261,6 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
     // Order blocks as if shown in the flyout.
     this.toolboxWorkspace.cleanUp_();
   }
-=======
-  // Clears workspace and loads next category.
-  this.clearAndLoadXml_(this.model.getSelectedXml());
-
-  // Selects the next tab.
-  this.view.setCategoryTabSelection(id, true);
-
-  // Order blocks as if shown in the flyout.
-  this.toolboxWorkspace.cleanUp_();
->>>>>>> Have basic pre-loaded workspace working
 
   // Update category editing buttons.
   this.view.updateState(this.model.getIndexByElementId
@@ -293,10 +282,12 @@ FactoryController.prototype.exportFile = function(exportMode) {
   // Generate XML.
   if (exportMode == FactoryController.MODE_TOOLBOX) {
     // Export the toolbox XML.
+
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateToolboxXml());
   } else if (exportMode == FactoryController.MODE_PRELOAD) {
     // Export the pre-loaded block XML.
+
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateWorkspaceXml());
   } else {
@@ -342,10 +333,12 @@ FactoryController.prototype.updatePreview = function() {
   // Disable events to stop updatePreview from recursively calling itself
   // through event handlers.
   Blockly.Events.disable();
-<<<<<<< f68f7c4a490dfb2ccc0db7b8f44930dc316ee38b
 
   if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
     // If currently editing the toolbox.
+    // Capture any changes made by user before generating XML.
+    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+>>>>>>> Have import/export functionality complete
     // Get toolbox XML.
     var tree = Blockly.Options.parseToolboxTree
         (this.generator.generateToolboxXml());
@@ -372,22 +365,12 @@ FactoryController.prototype.updatePreview = function() {
     // blocks don't get cleared when updating preview from event listeners while
     // switching modes.
     this.previewWorkspace.clear();
-<<<<<<< 8d894a801cfe834cbaa1a468d1430524e90e4527
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
   } else if (this.selectedMode == FactoryController.MODE_PRELOAD){
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
-=======
-    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
-        (this.model.getPreloadXml()), this.previewWorkspace);
-  } else {
-    // If currently editing the pre-loaded workspace.
-    this.previewWorkspace.clear();
-    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
-        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)),
->>>>>>> Have basic import options working
         this.previewWorkspace);
   }
 
@@ -633,12 +616,7 @@ FactoryController.prototype.addSeparator = function() {
  *    user is importing (FactoryController.MODE_TOOLBOX or
  *    FactoryController.MODE_PRELOAD).
  */
-<<<<<<< 8d894a801cfe834cbaa1a468d1430524e90e4527
 FactoryController.prototype.importFile = function(file, importMode) {
-=======
- // UPDATE COMMENTS
-FactoryController.prototype.importFile = function(file, isToolbox) {
->>>>>>> Have basic import options working
   // Exit if cancelled.
   if (!file) {
     return;
@@ -649,9 +627,8 @@ FactoryController.prototype.importFile = function(file, isToolbox) {
   reader.onload = function() {
     // Try to parse XML from file and load it into toolbox editing area.
     // Print error message if fail.
-    //try {
+    try {
       var tree = Blockly.Xml.textToDom(reader.result);
-<<<<<<< 8d894a801cfe834cbaa1a468d1430524e90e4527
       if (importMode == FactoryController.MODE_TOOLBOX) {
         // Switch mode and import toolbox XML.
         controller.setMode(FactoryController.MODE_TOOLBOX);
@@ -668,20 +645,6 @@ FactoryController.prototype.importFile = function(file, isToolbox) {
       alert('Cannot load XML from file.');
       console.log(e);
     }
-=======
-      if (isToolbox) {
-        controller.setMode(FactoryController.MODE_TOOLBOX);
-        controller.importToolboxFromTree_(tree);
-      } else {
-        controller.setMode(FactoryController.MODE_PRELOAD);
-        controller.importPreloadFromTree_(tree);
-      }
-    // } catch(e) {
-    //   alert('Cannot load XML from file.');
-    //   console.log(e);
-    //   console.log(e.lineno);
-    // }
->>>>>>> Have basic import options working
   }
 
   // Read the file asynchronously.
@@ -759,12 +722,18 @@ FactoryController.prototype.importToolboxFromTree_ = function(tree) {
   this.updatePreview();
 };
 
+/**
+ * Given a XML DOM tree, loads it into the pre-loaded workspace editing area.
+ * Assumes that tree is in valid XML format and that the selected mode is
+ * MODE_PRELOAD.
+ *
+ * @param {!Element} tree XML tree to be loaded to pre-loaded block editing
+ *    area.
+ */
 FactoryController.prototype.importPreloadFromTree_ = function(tree) {
   this.clearAndLoadXml_(tree);
   this.model.savePreloadXml(tree);
-  this.updatePreview(); //assuming that updatePreview still calls domToWorkspace regardless of mode
-  // this.previewWorkspace.domToWorkspace
-  //     (this.generator.generateWorkspaceXml(tree));
+  this.updatePreview();
 }
 
 /**
@@ -888,15 +857,10 @@ FactoryController.prototype.setMode = function(mode) {
 
   if (mode == FactoryController.MODE_TOOLBOX) {
     // Open the toolbox editing space.
-<<<<<<< 8d894a801cfe834cbaa1a468d1430524e90e4527
     document.getElementById('editHelpText').textContent =
         'Drag blocks into your toolbox:';
     this.model.savePreloadXml
         (Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
-=======
-    this.model.savePreloadXml(this.generator.generateWorkspaceXml
-        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)));
->>>>>>> Have basic import options working
     this.clearAndLoadXml_(this.model.getSelectedXml());
     this.view.disableWorkspace(this.view.shouldDisableWorkspace
         (this.model.getSelected()));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -514,17 +514,16 @@ FactoryController.prototype.loadCategory = function() {
     return;
   }
 
+  var firstCategory = !this.model.hasToolbox();
   // Copy the standard category in the model.
   var copy = standardCategory.copy();
-
-  // Add the copy in the view.
-  var tab = this.view.addCategoryRow(copy.name, copy.id,
-      !this.model.hasToolbox());
 
   // Add it to the model.
   this.model.addElementToList(copy);
 
-  // Update the view.
+  // Update the copy in the view.
+  var tab = this.view.addCategoryRow(copy.name, copy.id, firstCategory);
+
   this.addClickToSwitch(tab, copy.id);
   // Color the category tab in the view.
   if (copy.color) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -276,7 +276,8 @@ FactoryController.prototype.exportFile = function(exportMode) {
     if (this.selectedMode == FactoryController.MODE_PRELOAD) {
       // Capture any changes made by user before generating XML if in
       // preload workspace mode.
-      this.model.savePreloadXml(Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+      this.model.savePreloadXml(Blockly.Xml.workspaceToDom
+          (this.toolboxWorkspace));
     }
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateWorkspaceXml());

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -1,4 +1,24 @@
 /**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * @fileoverview Contains the controller code for workspace factory. Depends
  * on the model and view objects (created as internal variables) and interacts
  * with previewWorkspace and toolboxWorkspace (internal references stored to

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -456,7 +456,7 @@ FactoryController.prototype.loadCategory = function() {
   // Switch to loaded category.
   this.switchElement(copy.id);
   // Convert actual shadow blocks to user-generated shadow blocks.
-  this.convertShadowBlocks_();
+  this.convertShadowBlocks();
   // Update preview.
   this.updatePreview();
 };
@@ -553,7 +553,7 @@ FactoryController.prototype.importFromTree_ = function(tree) {
     this.toolboxWorkspace.cleanUp_();
 
     // Convert actual shadow blocks to user-generated shadow blocks.
-    this.convertShadowBlocks_();
+    this.convertShadowBlocks();
 
     // Add message to denote empty category.
     this.view.addEmptyCategoryMessage();
@@ -578,7 +578,7 @@ FactoryController.prototype.importFromTree_ = function(tree) {
         this.toolboxWorkspace.cleanUp_();
 
         // Convert actual shadow blocks to user-generated shadow blocks.
-        this.convertShadowBlocks_();
+        this.convertShadowBlocks();
 
         // Set category color.
         if (item.color) {
@@ -661,7 +661,7 @@ FactoryController.prototype.isUserGenShadowBlock = function(blockId) {
  * shadow blocks in the view but are still editable and movable.
  * @private
  */
-FactoryController.prototype.convertShadowBlocks_ = function() {
+FactoryController.prototype.convertShadowBlocks = function() {
   var blocks = this.toolboxWorkspace.getAllBlocks();
   for (var i = 0, block; block = blocks[i]; i++) {
     if (block.isShadow()) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -659,7 +659,6 @@ FactoryController.prototype.isUserGenShadowBlock = function(blockId) {
  * all real shadow blocks loaded in the workspace into user-generated shadow
  * blocks, meaning they are marked as shadow blocks by the model and appear as
  * shadow blocks in the view but are still editable and movable.
- * @private
  */
 FactoryController.prototype.convertShadowBlocks = function() {
   var blocks = this.toolboxWorkspace.getAllBlocks();

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -643,6 +643,18 @@ FactoryController.prototype.removeShadow = function() {
 };
 
 /**
+ * Given a unique block ID, uses the model to determine if a block is a
+ * user-generated shadow block.
+ *
+ * @param {!string} blockId The unique ID of the block to examine.
+ * @return {boolean} True if the block is a user-generated shadow block, false
+ *    otherwise.
+ */
+FactoryController.prototype.isUserGenShadowBlock = function(blockId) {
+  return this.model.isShadowBlock(blockId);
+}
+
+/**
  * Call when importing XML containing real shadow blocks. This function turns
  * all real shadow blocks loaded in the workspace into user-generated shadow
  * blocks, meaning they are marked as shadow blocks by the model and appear as

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -64,7 +64,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
         'id' : 'toolbox',
         'style' : 'display:none'
       });
-  if (!this.model.hasToolbox()) {
+  if (!this.model.hasElements()) {
     // Toolbox has no categories. Use XML directly from workspace.
     this.loadToHiddenWorkspaceAndSave_(this.model.getSelectedXml(), xmlDom);
   } else {

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -114,7 +114,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
   * generated shadow blocks to actual shadow blocks.
   *
   */
- FactoryGenerator.prototype.generateWorkspaceXml = function() {
+FactoryGenerator.prototype.generateWorkspaceXml = function() {
   // Load workspace XML to hidden workspace with user-generated shadow blocks
   // as actual shadow blocks.
   this.hiddenWorkspace.clear();

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -117,10 +117,10 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   * @param {!Blockly.workspace} toolboxWorkspace The workspace to load XML
   *     from.
   */
- FactoryGenerator.prototype.generateWorkspaceXml = function(toolboxWorkspace) {
+  // UPDATE CoMMENTS
+ FactoryGenerator.prototype.generateWorkspaceXml = function(rawXml) {
   this.hiddenWorkspace.clear();
-  Blockly.Xml.domToWorkspace(Blockly.Xml.workspaceToDom(toolboxWorkspace),
-      this.hiddenWorkspace);
+  Blockly.Xml.domToWorkspace(rawXml, this.hiddenWorkspace);
   this.setShadowBlocksInHiddenWorkspace_();
   return Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
  }

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -108,7 +108,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
   return xmlDom;
  };
 
-<<<<<<< b52dd61f1b76c06b816c73ff4dccfce9fa9fd74f
+
  /**
   * Generates XML for the workspace (different from generateConfigXml in that
   * it includes XY and ID attributes). Uses a workspace and converts user

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -108,6 +108,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
   return xmlDom;
  };
 
+<<<<<<< b52dd61f1b76c06b816c73ff4dccfce9fa9fd74f
  /**
   * Generates XML for the workspace (different from generateConfigXml in that
   * it includes XY and ID attributes). Uses a workspace and converts user

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -86,7 +86,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
       if (element.type == ListElement.TYPE_SEPARATOR) {
         // If the next element is a separator.
         var nextElement = goog.dom.createDom('sep');
-      } else {
+      } else if (element.type == ListElement.TYPE_CATEGORY) {
         // If the next element is a category.
         var nextElement = goog.dom.createDom('category');
         nextElement.setAttribute('name', element.name);

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -109,6 +109,14 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   return xmlDom;
  };
 
+ FactoryGenerator.prototype.generateWorkspaceXml = function(toolboxWorkspace) {
+  this.hiddenWorkspace.clear();
+  Blockly.Xml.domToWorkspace(Blockly.Xml.workspaceToDom(toolboxWorkspace),
+      this.hiddenWorkspace);
+  this.setShadowBlocksInHiddenWorkspace_();
+  return Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
+ }
+
 /**
  * Load the given XML to the hidden workspace, set any user-generated shadow
  * blocks to be actual shadow blocks, then append the XML from the workspace

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -109,6 +109,14 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   return xmlDom;
  };
 
+ /**
+  * Generates XML for the workspace (different from generateConfigXml in that
+  * it includes XY and ID attributes). Uses a workspace and converts user
+  * generated shadow blocks to actual shadow blocks.
+  *
+  * @param {!Blockly.workspace} toolboxWorkspace The workspace to load XML
+  *     from.
+  */
  FactoryGenerator.prototype.generateWorkspaceXml = function(toolboxWorkspace) {
   this.hiddenWorkspace.clear();
   Blockly.Xml.domToWorkspace(Blockly.Xml.workspaceToDom(toolboxWorkspace),

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -1,4 +1,24 @@
 /**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * @fileoverview Generates the configuration xml used to update the preview
  * workspace or print to the console or download to a file. Leverages
  * Blockly.Xml and depends on information in the model (holds a reference).

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -39,8 +39,8 @@ FactoryModel = function() {
   this.toolboxList = [];
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // Currently selected ListElement. In list if there are categories, not in
-  // list if there is only a single flyout.
+  // Currently selected ListElement. In toolboxList if there are categories, not
+  // in toolboxList if there is only a single flyout.
   this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -129,6 +129,11 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
       false : this.hasProcedureCategory;
   // Remove element.
   this.toolboxList.splice(index, 1);
+  // If removing last element from toolbox list, create empty list element
+  // for single flyout.
+  if (this.toolboxList.length == 0) {
+    this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+  }
 };
 
 /**
@@ -380,11 +385,7 @@ FactoryModel.prototype.savePreloadXml = function(xml) {
  */
 FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
-<<<<<<< d69ceb7f6d014909fb5069d601f1ffb1ec01e308
-}
-=======
 };
->>>>>>> Have basic pre-loaded workspace working
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -134,6 +134,11 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
       false : this.hasProcedureCategory;
   // Remove element.
   this.toolboxList.splice(index, 1);
+  // If removing last element from toolbox list, create empty list element
+  // for single flyout.
+  if (this.toolboxList.length == 0) {
+    this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+  }
 };
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -51,6 +51,8 @@ FactoryModel = function() {
   this.hasProcedureCategory = false;
   // XML to be pre-loaded to workspace. Empty on default;
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
+  // Options object to be configured for Blockly inject call.
+  this.options = Object.create(null);
 };
 
 /**
@@ -413,6 +415,14 @@ FactoryModel.prototype.savePreloadXml = function(xml) {
  */
 FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
+};
+
+FactoryModel.prototype.setOptions = function(type, value) {
+  this.options[type] = value;
+  if (!type) {
+    console.log("UNDEF");
+  }
+  console.log(this.options);
 };
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -359,7 +359,6 @@ FactoryModel.prototype.getShadowBlocksInWorkspace = function(workspaceBlocks) {
   return shadowsInWorkspace;
 };
 
-<<<<<<< b52dd61f1b76c06b816c73ff4dccfce9fa9fd74f
 /**
  * Adds a custom tag to a category, updating state variables accordingly.
  * Only accepts 'VARIABLE' and 'PROCEDURE' tags.
@@ -382,7 +381,8 @@ FactoryModel.prototype.addCustomTag = function(category, tag) {
   }
 };
 
-/*
+/**
+ * Have basic pre-loaded workspace working
  * Saves XML as XML to be pre-loaded into the workspace.
  *
  * @param {!Element} xml The XML to be saved.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -91,9 +91,9 @@ FactoryModel.prototype.hasProcedures = function() {
  * Determines if the user has any elements in the toolbox. Uses the length of
  * toolboxList.
  *
- * @return {boolean} True if categories exist, false otherwise.
+ * @return {boolean} True if elements exist, false otherwise.
  */
-FactoryModel.prototype.hasToolbox = function() {
+FactoryModel.prototype.hasElements = function() {
   return this.toolboxList.length > 0;
 };
 
@@ -129,17 +129,16 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
       false : this.hasProcedureCategory;
   // Remove element.
   this.toolboxList.splice(index, 1);
-  // If removing last element from toolbox list, create empty list element
-  // for single flyout.
-
 };
 
 /**
  * Sets selected to be an empty category not in toolbox list if toolbox list
  * is empty. Should be called when removing the last element from toolbox list.
+ * If the toolbox list is empty, selected stores the XML for the single flyout
+ * of blocks displayed.
  *
  */
-FactoryModel.prototype.setDefaultSelected = function() {
+FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
   if (this.toolboxList.length == 0) {
     this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   }

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -52,7 +52,8 @@ FactoryModel = function() {
   // XML to be pre-loaded to workspace. Empty on default;
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
   // Options object to be configured for Blockly inject call.
-  this.options = Object.create(null);
+  this.options = new Object(null);
+  //this.options = goog.dom.createDom();
 };
 
 /**
@@ -417,13 +418,26 @@ FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
 };
 
-FactoryModel.prototype.setOptions = function(type, value) {
+FactoryModel.prototype.setOption = function(type, value) {
   this.options[type] = value;
+  //this.options.setAttribute(type, value)
   if (!type) {
     console.log("UNDEF");
   }
   console.log(this.options);
 };
+
+FactoryModel.prototype.setSubOption = function(option, type, value) {
+  if (!this.options[option]) {
+    console.log("new option: " + option);
+    this.options[option] = new Object(null);
+  }
+  this.options[option][type] = value;
+};
+
+FactoryModel.prototype.removeOption = function(type) {
+  delete this.options[type];
+}
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -53,7 +53,6 @@ FactoryModel = function() {
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
   // Options object to be configured for Blockly inject call.
   this.options = new Object(null);
-  //this.options = goog.dom.createDom();
 };
 
 /**
@@ -418,23 +417,42 @@ FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
 };
 
+/**
+ * Adds an attribute to the options object with the name type and the value
+ * value.
+ *
+ * @param {!string} type The name of the attribute to give to the options
+ *    object.
+ * @param {Object} value The value of the attribute added to options.
+ */
 FactoryModel.prototype.setOption = function(type, value) {
   this.options[type] = value;
-  //this.options.setAttribute(type, value)
-  if (!type) {
-    console.log("UNDEF");
-  }
-  console.log(this.options);
 };
 
+/**
+ * Adds an attribute to an object within the options object. If an option with
+ * that name does not exist, create a new one.
+ *
+ * @param {!string} The name of the object within the options object to add
+ *    the attribute to.
+ * @param {!string} type The name of the attribute to add to the object within
+ *    options.
+ * @param {Object} value The value of the attribute to be added to the object
+ *    within options.
+ */
 FactoryModel.prototype.setSubOption = function(option, type, value) {
   if (!this.options[option]) {
-    console.log("new option: " + option);
     this.options[option] = new Object(null);
   }
   this.options[option][type] = value;
 };
 
+/**
+ * Removes an option within the options object.
+ *
+ * @param {!string} type the name of the attribute to be removed from the
+ *    options object.
+ */
 FactoryModel.prototype.removeOption = function(type) {
   delete this.options[type];
 }

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -418,44 +418,23 @@ FactoryModel.prototype.getPreloadXml = function() {
 };
 
 /**
- * Adds an attribute to the options object with the name type and the value
- * value.
+ * Sets a new options object for injecting a Blockly workspace.
  *
- * @param {!string} type The name of the attribute to give to the options
- *    object.
- * @param {Object} value The value of the attribute added to options.
+ * @param {Object} options Options object for injecting a Blockly workspace.
  */
-FactoryModel.prototype.setOption = function(type, value) {
-  this.options[type] = value;
+FactoryModel.prototype.setOptions = function(options) {
+  this.options = options;
 };
 
 /**
- * Adds an attribute to an object within the options object. If an option with
- * that name does not exist, create a new one.
+ * Sets an attribute of the options object.
  *
- * @param {!string} The name of the object within the options object to add
- *    the attribute to.
- * @param {!string} type The name of the attribute to add to the object within
- *    options.
- * @param {Object} value The value of the attribute to be added to the object
- *    within options.
+ * @param {!string} name Name of the attribute to add.
+ * @param {Object} value The value of the attribute to add.
  */
-FactoryModel.prototype.setSubOption = function(option, type, value) {
-  if (!this.options[option]) {
-    this.options[option] = new Object(null);
-  }
-  this.options[option][type] = value;
+FactoryModel.prototype.setOptionsAttribute = function(name, value) {
+  this.options[name] = value;
 };
-
-/**
- * Removes an option within the options object.
- *
- * @param {!string} type the name of the attribute to be removed from the
- *    options object.
- */
-FactoryModel.prototype.removeOption = function(type) {
-  delete this.options[type];
-}
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -136,18 +136,6 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
       false : this.hasProcedureCategory;
   // Remove element.
   this.toolboxList.splice(index, 1);
-<<<<<<< 5c38b1f7f28b9490385f0649e2c7ebd6b2f348f4
-  // If removing last element from toolbox list, create empty list element
-  // for single flyout.
-  if (this.toolboxList.length == 0) {
-    this.selected = new ListElement(ListElement.TYPE_CATEGORY);
-  }
-};
-
-/**
- * Sets selected to be an empty single flyout if toolbox list is empty. Should
- * be called when removing the last element from toolbox list.
-=======
 };
 
 /**
@@ -155,7 +143,6 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
  * is empty. Should be called when removing the last element from toolbox list.
  * If the toolbox list is empty, selected stores the XML for the single flyout
  * of blocks displayed.
->>>>>>> Added saveStateFromWorkspace, changed the names of some variables and methods
  *
  */
 FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -35,13 +35,15 @@
  * @constructor
  */
 FactoryModel = function() {
-  // Ordered list of ListElement objects.
+  // Ordered list of ListElement objects. Empty if there is a single flyout.
   this.toolboxList = [];
+  // ListElement for blocks in a single flyout. Null if a toolbox exists.
+  this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // Currently selected ListElement. In toolboxList if there are categories, not
-  // in toolboxList if there is only a single flyout.
-  this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+  // Currently selected ListElement. In toolboxList if there are categories, in
+  // flyout if all blocks are displayed in a single flyout.
+  this.selected = this.flyout;
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
   // Boolean for if a Procedure category has been added.
@@ -110,6 +112,8 @@ FactoryModel.prototype.addElementToList = function(element) {
       this.hasProcedureCategory;
   // Add element to toolboxList.
   this.toolboxList.push(element);
+  // Empty single flyout.
+  this.flyout = null;
 };
 
 /**
@@ -132,15 +136,14 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
 };
 
 /**
- * Sets selected to be an empty category not in toolbox list if toolbox list
- * is empty. Should be called when removing the last element from toolbox list.
- * If the toolbox list is empty, selected stores the XML for the single flyout
- * of blocks displayed.
+ * Sets selected to be an empty single flyout if toolbox list is empty. Should
+ * be called when removing the last element from toolbox list.
  *
  */
 FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
   if (this.toolboxList.length == 0) {
-    this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+    this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
+    this.selected = this.flyout;
   }
 }
 
@@ -416,6 +419,7 @@ ListElement = function(type, opt_name) {
 // List element types.
 ListElement.TYPE_CATEGORY = 'category';
 ListElement.TYPE_SEPARATOR = 'separator';
+ListElement.TYPE_FLYOUT = 'flyout';
 
 /**
  * Saves a category by updating its XML (does not save XML for
@@ -425,8 +429,8 @@ ListElement.TYPE_SEPARATOR = 'separator';
  * from.
  */
 ListElement.prototype.saveFromWorkspace = function(workspace) {
-  // Only save list elements that are categories.
-  if (this.type != ListElement.TYPE_CATEGORY) {
+  // Don't save anything from separators.
+  if (this.type == ListElement.TYPE_SEPARATOR) {
     return;
   }
   this.xml = Blockly.Xml.workspaceToDom(workspace);
@@ -441,7 +445,7 @@ ListElement.prototype.saveFromWorkspace = function(workspace) {
  */
 ListElement.prototype.changeName = function (name) {
   // Only update list elements that are categories.
-  if (this.type != ListElement.TYPE_CATEGORY) {
+  if (this.type == ListElement.TYPE_CATEGORY) {
     return;
   }
   this.name = name;

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -258,6 +258,8 @@ FactoryModel.prototype.getCategoryIdByName = function(name) {
  */
 FactoryModel.prototype.clearToolboxList = function() {
   this.toolboxList = [];
+  this.hasVariableCategory = false;
+  this.hasVariableCategory = false;
   // TODO(evd2014): When merge changes, also clear shadowList.
 };
 
@@ -316,6 +318,28 @@ FactoryModel.prototype.getShadowBlocksInWorkspace = function(workspaceBlocks) {
     }
   }
   return shadowsInWorkspace;
+};
+
+/**
+ * Adds a custom tag to a category, updating state variables accordingly.
+ * Only accepts 'VARIABLE' and 'PROCEDURE' tags.
+ *
+ * @param {!ListElement} category The category to add the tag to.
+ * @param {!string} tag The custom tag to add to the category.
+ */
+FactoryModel.prototype.addCustomTag = function(category, tag) {
+  // Only update list elements that are categories.
+  if (category.type != ListElement.TYPE_CATEGORY) {
+    return;
+  }
+  // Only update the tag to be 'VARIABLE' or 'PROCEDURE'.
+  if (tag == 'VARIABLE') {
+    this.hasVariableCategory = true;
+    category.custom = 'VARIABLE';
+  } else if (tag == 'PROCEDURE') {
+    this.hasProcedureCategory = true;
+    category.custom = 'PROCEDURE';
+  }
 };
 
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -41,8 +41,9 @@ FactoryModel = function() {
   this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // Reference to currently selected ListElement. Stored in toolboxList if there
-  // are categories, or in flyout if blocks are displayed in a single flyout.
+  // Reference to currently selected ListElement. Stored in this.toolboxList if
+  // there are categories, or in this.flyout if blocks are displayed in a single
+  // flyout.
   this.selected = this.flyout;
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -131,10 +131,19 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
   this.toolboxList.splice(index, 1);
   // If removing last element from toolbox list, create empty list element
   // for single flyout.
+
+};
+
+/**
+ * Sets selected to be an empty category not in toolbox list if toolbox list
+ * is empty. Should be called when removing the last element from toolbox list.
+ *
+ */
+FactoryModel.prototype.setDefaultSelected = function() {
   if (this.toolboxList.length == 0) {
     this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   }
-};
+}
 
 /**
  * Moves a list element to a certain position in toolboxList by removing it

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -359,6 +359,7 @@ FactoryModel.prototype.getShadowBlocksInWorkspace = function(workspaceBlocks) {
   return shadowsInWorkspace;
 };
 
+<<<<<<< b52dd61f1b76c06b816c73ff4dccfce9fa9fd74f
 /**
  * Adds a custom tag to a category, updating state variables accordingly.
  * Only accepts 'VARIABLE' and 'PROCEDURE' tags.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -40,11 +40,13 @@ FactoryModel = function() {
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
   // String name of current selected list element, null if no list elements.
-  this.selected = null;
+  this.selected = new ListElement(ListElement.TYPE_CATEGORY); // make type default? update categories
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
   // Boolean for if a Procedure category has been added.
   this.hasProcedureCategory = false;
+  // XML to be pre-loaded to workspace. Empty on default;
+  this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
 };
 
 // String name of current selected list element, null if no list elements.
@@ -364,6 +366,13 @@ FactoryModel.prototype.addCustomTag = function(category, tag) {
   }
 };
 
+FactoryModel.prototype.savePreloadXml = function(xml) {
+  this.preloadXml = xml
+};
+
+FactoryModel.prototype.getPreloadXml = function() {
+  return this.preloadXml;
+}
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -39,8 +39,9 @@ FactoryModel = function() {
   this.toolboxList = [];
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // String name of current selected list element, null if no list elements.
-  this.selected = new ListElement(ListElement.TYPE_CATEGORY); // make type default? update categories
+  // Currently selected ListElement. In list if there are categories, not in
+  // list if there is only a single flyout.
+  this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
   // Boolean for if a Procedure category has been added.
@@ -48,9 +49,6 @@ FactoryModel = function() {
   // XML to be pre-loaded to workspace. Empty on default;
   this.preloadXml = Blockly.Xml.textToDom('<xml></xml>');
 };
-
-// String name of current selected list element, null if no list elements.
-FactoryModel.prototype.selected = null;
 
 /**
  * Given a name, determines if it is the name of a category already present.
@@ -366,13 +364,27 @@ FactoryModel.prototype.addCustomTag = function(category, tag) {
   }
 };
 
+/*
+ * Saves XML as XML to be pre-loaded into the workspace.
+ *
+ * @param {!Element} xml The XML to be saved.
+ */
 FactoryModel.prototype.savePreloadXml = function(xml) {
   this.preloadXml = xml
 };
 
+/**
+ * Gets the XML to be pre-loaded into the workspace.
+ *
+ * @return {!Element} The XML for the workspace.
+ */
 FactoryModel.prototype.getPreloadXml = function() {
   return this.preloadXml;
+<<<<<<< d69ceb7f6d014909fb5069d601f1ffb1ec01e308
 }
+=======
+};
+>>>>>>> Have basic pre-loaded workspace working
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -134,6 +134,7 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
       false : this.hasProcedureCategory;
   // Remove element.
   this.toolboxList.splice(index, 1);
+<<<<<<< 5c38b1f7f28b9490385f0649e2c7ebd6b2f348f4
   // If removing last element from toolbox list, create empty list element
   // for single flyout.
   if (this.toolboxList.length == 0) {
@@ -144,6 +145,15 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
 /**
  * Sets selected to be an empty single flyout if toolbox list is empty. Should
  * be called when removing the last element from toolbox list.
+=======
+};
+
+/**
+ * Sets selected to be an empty category not in toolbox list if toolbox list
+ * is empty. Should be called when removing the last element from toolbox list.
+ * If the toolbox list is empty, selected stores the XML for the single flyout
+ * of blocks displayed.
+>>>>>>> Added saveStateFromWorkspace, changed the names of some variables and methods
  *
  */
 FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -41,8 +41,8 @@ FactoryModel = function() {
   this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // Currently selected ListElement. In toolboxList if there are categories, in
-  // flyout if all blocks are displayed in a single flyout.
+  // Reference to currently selected ListElement. Stored in toolboxList if there
+  // are categories, or in flyout if blocks are displayed in a single flyout.
   this.selected = this.flyout;
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
@@ -429,11 +429,11 @@ ListElement.TYPE_FLYOUT = 'flyout';
  * from.
  */
 ListElement.prototype.saveFromWorkspace = function(workspace) {
-  // Don't save anything from separators.
-  if (this.type == ListElement.TYPE_SEPARATOR) {
-    return;
+  // Only save XML for categories and flyouts.
+  if (this.type == ListElement.TYPE_FLYOUT ||
+      this.type == ListElement.TYPE_CATEGORY) {
+    this.xml = Blockly.Xml.workspaceToDom(workspace);
   }
-  this.xml = Blockly.Xml.workspaceToDom(workspace);
 };
 
 
@@ -445,7 +445,7 @@ ListElement.prototype.saveFromWorkspace = function(workspace) {
  */
 ListElement.prototype.changeName = function (name) {
   // Only update list elements that are categories.
-  if (this.type == ListElement.TYPE_CATEGORY) {
+  if (this.type != ListElement.TYPE_CATEGORY) {
     return;
   }
   this.name = name;

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -290,6 +290,8 @@ FactoryModel.prototype.removeShadowBlock = function(blockId) {
  * Determines if a block is a shadow block given a unique block ID.
  *
  * @param {!string} blockId The unique ID of the block to examine.
+ * @return {boolean} True if the block is a user-generated shadow block, false
+ *    otherwise.
  */
 FactoryModel.prototype.isShadowBlock = function(blockId) {
   for (var i = 0; i < this.shadowBlocks.length; i++) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -1,4 +1,24 @@
 /**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * @fileoverview Stores and updates information about state and categories
  * in workspace factory. Each list element is either a separator or a category,
  * and each category stores its name, XML to load that category, color,

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -339,3 +339,21 @@ FactoryView.prototype.unmarkShadowBlock = function(block) {
     Blockly.removeClass_(block.svgGroup_, 'shadowBlock');
   }
 };
+
+/**
+ * Sets the tabs for modes according to which mode the user is currenly
+ * editing in.
+ *
+ * @param {!string} tab The type of tab being switched to
+ *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
+ */
+FactoryView.prototype.setModeSelection = function(mode) {
+  document.getElementById('tab_preload').className = mode ==
+      FactoryController.MODE_PRELOAD ? 'tabon' : 'taboff';
+  document.getElementById('preload_div').style.display = mode ==
+      FactoryController.MODE_PRELOAD ? 'block' : 'none';
+  document.getElementById('tab_toolbox').className = mode ==
+      FactoryController.MODE_TOOLBOX ? 'tabon' : 'taboff';
+  document.getElementById('toolbox_div').style.display = mode ==
+      FactoryController.MODE_TOOLBOX ? 'block' : 'none';
+};

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -344,7 +344,7 @@ FactoryView.prototype.unmarkShadowBlock = function(block) {
  * Sets the tabs for modes according to which mode the user is currenly
  * editing in.
  *
- * @param {!string} tab The type of tab being switched to
+ * @param {!string} mode The mode being switched to
  *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
  */
 FactoryView.prototype.setModeSelection = function(mode) {
@@ -356,4 +356,16 @@ FactoryView.prototype.setModeSelection = function(mode) {
       FactoryController.MODE_TOOLBOX ? 'tabon' : 'taboff';
   document.getElementById('toolbox_div').style.display = mode ==
       FactoryController.MODE_TOOLBOX ? 'block' : 'none';
+};
+
+/**
+ * Updates the help text above the workspace depending on the selected mode.
+ *
+ * @param {!string} mode The selected mode (FactoryController.MODE_TOOLBOX or
+ *    FactoryController.MODE_PRELOAD).
+ */
+FactoryView.prototype.updateHelpText = function(mode) {
+  var helpText = 'Drag your blocks into your ' + (mode ==
+      FactoryController.MODE_TOOLBOX ? 'toolbox: ' : 'pre-loaded workspace: ');
+  document.getElementById('editHelpText').textContent = helpText;
 };

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -344,7 +344,11 @@ FactoryView.prototype.unmarkShadowBlock = function(block) {
  * Sets the tabs for modes according to which mode the user is currenly
  * editing in.
  *
+<<<<<<< f68f7c4a490dfb2ccc0db7b8f44930dc316ee38b
  * @param {!string} mode The mode being switched to
+=======
+ * @param {!string} tab The type of tab being switched to
+>>>>>>> Have basic pre-loaded workspace working
  *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
  */
 FactoryView.prototype.setModeSelection = function(mode) {
@@ -357,6 +361,7 @@ FactoryView.prototype.setModeSelection = function(mode) {
   document.getElementById('toolbox_div').style.display = mode ==
       FactoryController.MODE_TOOLBOX ? 'block' : 'none';
 };
+<<<<<<< f68f7c4a490dfb2ccc0db7b8f44930dc316ee38b
 
 /**
  * Updates the help text above the workspace depending on the selected mode.
@@ -369,3 +374,5 @@ FactoryView.prototype.updateHelpText = function(mode) {
       FactoryController.MODE_TOOLBOX ? 'toolbox: ' : 'pre-loaded workspace: ');
   document.getElementById('editHelpText').textContent = helpText;
 };
+=======
+>>>>>>> Have basic pre-loaded workspace working

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -300,6 +300,11 @@ FactoryView.prototype.markShadowBlocks = function(blocks) {
 FactoryView.prototype.markShadowBlock = function(block) {
   // Add Blockly CSS for user-generated shadow blocks.
   Blockly.addClass_(block.svgGroup_, 'shadowBlock');
+  // If not a valid shadow block, add a warning message.
+  if (!block.getSurroundParent()) {
+      block.setWarningText('Shadow blocks must be nested inside' +
+          ' other blocks to be displayed.');
+  }
 };
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -344,11 +344,7 @@ FactoryView.prototype.unmarkShadowBlock = function(block) {
  * Sets the tabs for modes according to which mode the user is currenly
  * editing in.
  *
-<<<<<<< f68f7c4a490dfb2ccc0db7b8f44930dc316ee38b
  * @param {!string} mode The mode being switched to
-=======
- * @param {!string} tab The type of tab being switched to
->>>>>>> Have basic pre-loaded workspace working
  *    (FactoryController.MODE_TOOLBOX or FactoryController.MODE_PRELOAD).
  */
 FactoryView.prototype.setModeSelection = function(mode) {
@@ -361,7 +357,6 @@ FactoryView.prototype.setModeSelection = function(mode) {
   document.getElementById('toolbox_div').style.display = mode ==
       FactoryController.MODE_TOOLBOX ? 'block' : 'none';
 };
-<<<<<<< f68f7c4a490dfb2ccc0db7b8f44930dc316ee38b
 
 /**
  * Updates the help text above the workspace depending on the selected mode.
@@ -374,5 +369,53 @@ FactoryView.prototype.updateHelpText = function(mode) {
       FactoryController.MODE_TOOLBOX ? 'toolbox: ' : 'pre-loaded workspace: ');
   document.getElementById('editHelpText').textContent = helpText;
 };
-=======
->>>>>>> Have basic pre-loaded workspace working
+
+/**
+ * Sets the basic options that are not dependent on if there are categories
+ * or a single flyout of blocks. Updates checkboxes and text fields.
+ */
+FactoryView.prototype.setBaseOptions = function() {
+  // Set basic options.
+  document.getElementById('option_css_checkbox').checked = true;
+  document.getElementById('option_maxBlocks_text').value = Infinity;
+  document.getElementById('option_media_text').value =
+      'https://blockly-demo.appspot.com/static/media/';
+  document.getElementById('option_readOnly_checkbox').checked = false;
+  document.getElementById('option_rtl_checkbox').checked = false;
+  document.getElementById('option_sounds_checkbox').checked = true;
+
+  // Uncheck grid and zoom options and hide suboptions.
+  document.getElementById('option_grid_checkbox').checked = false;
+  document.getElementById('grid_options').style.display = 'none';
+  document.getElementById('option_zoom_checkbox').checked = false;
+  document.getElementById('zoom_options').style.display = 'none';
+
+  // Set grid options.
+  document.getElementById('gridOption_spacing_text').value = 0;
+  document.getElementById('gridOption_length_text').value = 1;
+  document.getElementById('gridOption_colour_text').value = '#888';
+  document.getElementById('gridOption_snap_checkbox').checked = false;
+
+  // Set zoom options.
+  document.getElementById('zoomOption_controls_checkbox').checked = false;
+  document.getElementById('zoomOption_wheel_checkbox').checked = false;
+  document.getElementById('zoomOption_startScale_text').value = 1.0;
+  document.getElementById('zoomOption_maxScale_text').value = 3;
+  document.getElementById('zoomOption_minScale_text').value = 0.3;
+  document.getElementById('zoomOption_scaleSpeed_text').value = 1.2;
+};
+
+/**
+ * Updates category specific options depending on if there are categories
+ * currently present. Updates checkboxes and text fields in the view.
+ *
+ * @param {boolean} hasCategories True if categories are present, false if all
+ *    blocks are displayed in a single flyout.
+ */
+FactoryView.prototype.setCategoryOptions = function(hasCategories) {
+  document.getElementById('option_collapse_checkbox').checked = hasCategories;
+  document.getElementById('option_comments_checkbox').checked = hasCategories;
+  document.getElementById('option_disable_checkbox').checked = hasCategories;
+  document.getElementById('option_scrollbars_checkbox').checked = hasCategories;
+  document.getElementById('option_trashcan_checkbox').checked = hasCategories;
+}

--- a/demos/blocklyfactory/workspacefactory/wfactory_view.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_view.js
@@ -1,4 +1,24 @@
 /**
+ * @license
+ * Visual Blocks Editor
+ *
+ * Copyright 2016 Google Inc.
+ * https://developers.google.com/blockly/
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
  * Controls the UI elements for workspace factory, mainly the category tabs.
  * Also includes downloading files because that interacts directly with the DOM.
  * Depends on FactoryController (for adding mouse listeners). Tabs for each


### PR DESCRIPTION
Allows the user to configure the options object used to inject Blockly with checkboxes and text fields. Updates the preview workspace automatically to reflect changes to the options object. Uses the Blockly default values to start with and allows the user to revert to those with a button. On changing from a single flyout to categories or categories to a single flyout, asks the user if they would like to use category or flyout specific default option values (e.g. scrollbars, trashcan, etc.). Allows the user to save the options object to a file. 

Files changed: index.html, style.css (very minor, small button), wfactory_controller.js, wfactory_model.js
![options no grid](https://cloud.githubusercontent.com/assets/18580768/17569834/c94a4e6c-5efe-11e6-9074-c0e9cf71627e.png)
![options with grid](https://cloud.githubusercontent.com/assets/18580768/17569832/c7807ef8-5efe-11e6-906b-886c60d2fb71.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/41)

<!-- Reviewable:end -->
