### PR TITLE
Workspace Factory #17: Get block types currently used

### DIFF
--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -30,10 +30,26 @@ goog.require('goog.ui.ColorPicker');
   <tr>
     <td>
       <p>
-        <input type="file" id="input_import" class="inputfile"></input>
-        <label for="input_import">Import</label>
+        <div class="dropdown">
+        <button id="button_import">Import</button>
+        <div id="dropdownDiv_import" class="dropdown-content">
+          <input type="file" id="input_importToolbox" class="inputfile"></input>
+          <label for="input_importToolbox">Toolbox</label>
+          <input type="file" id="input_importPreload" class="inputfile"></input>
+          <label for="input_importPreload">Workspace Blocks</label>
+        </div>
+        </div>
+
+        <div class="dropdown">
         <button id="button_export">Export</button>
-        <button id="button_print">Print</button>
+        <div id="dropdownDiv_export" class="dropdown-content">
+          <a id='dropdown_exportToolbox'>Toolbox</a>
+          <a id='dropdown_exportPreload'>Workspace Blocks</a>
+          <a id='dropdown_exportAll'>All</a>
+        </div>
+        </div>
+
+        <button id="button_print">Print Toolbox</button>
         <button id="button_clear">Clear</button>
       </p>
     </td>
@@ -514,7 +530,8 @@ goog.require('goog.ui.ColorPicker');
     controller.removeElement();
   };
   var exportWrapper = function() {
-    controller.exportConfig();
+    document.getElementById('dropdownDiv_export').classList.toggle("show");
+    //controller.exportConfig();
   };
   var printWrapper = function() {
     controller.printConfig();
@@ -559,18 +576,27 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
-  var importWrapper = function(event) {
-    controller.importFile(event.target.files[0]);
+  var importWrapper = function() {  // took an event e before, need to have listener with 'change' for files
+    document.getElementById('dropdownDiv_import').classList.toggle("show");
+    //controller.importFile(event.target.files[0]);
   };
   var clearWrapper = function() {
     controller.clear();
-  }
+  };
   var editToolboxWrapper = function() {
     controller.setMode(FactoryController.MODE_TOOLBOX);
-  }
+  };
   var editPreloadWrapper = function() {
     controller.setMode(FactoryController.MODE_PRELOAD);
-  }
+  };
+  var importToolboxWrapper = function(e) {
+    controller.importFile(event.target.files[0], true);
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
+  var importPreloadWrapper = function(e) {
+    controller.importFile(event.target.files[0]), false;
+    document.getElementById('dropdownDiv_import').classList.remove("show");
+  };
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -596,8 +622,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', editShadowWrapper);
   document.getElementById('dropdown_name').addEventListener
       ('click', nameWrapper);
-  document.getElementById('input_import').addEventListener
-      ('change', importWrapper);
+  document.getElementById('button_import').addEventListener
+      ('click', importWrapper);
+  document.getElementById('input_importToolbox').addEventListener
+      ('change', importToolboxWrapper);
+  document.getElementById('input_importPreload').addEventListener
+      ('change', importPreloadWrapper);
   document.getElementById('button_clear').addEventListener
       ('click', clearWrapper);
   document.getElementById('dropdown_editShadowAdd').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -531,7 +531,7 @@ goog.require('goog.ui.ColorPicker');
   };
   var exportWrapper = function() {
     document.getElementById('dropdownDiv_export').classList.toggle("show");
-    //controller.exportConfig();
+    document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var printWrapper = function() {
     controller.printConfig();
@@ -576,9 +576,9 @@ goog.require('goog.ui.ColorPicker');
       }
     }
   };
-  var importWrapper = function() {  // took an event e before, need to have listener with 'change' for files
+  var importWrapper = function() {
     document.getElementById('dropdownDiv_import').classList.toggle("show");
-    //controller.importFile(event.target.files[0]);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
   };
   var clearWrapper = function() {
     controller.clear();
@@ -590,13 +590,26 @@ goog.require('goog.ui.ColorPicker');
     controller.setMode(FactoryController.MODE_PRELOAD);
   };
   var importToolboxWrapper = function(e) {
-    controller.importFile(event.target.files[0], true);
+    controller.importFile(event.target.files[0], FactoryController.MODE_TOOLBOX);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
   var importPreloadWrapper = function(e) {
-    controller.importFile(event.target.files[0]), false;
+    controller.importFile(event.target.files[0], FactoryController.MODE_PRELOAD);
     document.getElementById('dropdownDiv_import').classList.remove("show");
   };
+  var exportToolboxWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportPreloadWrapper = function() {
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
+  var exportAllWrapper = function() {
+    controller.exportFile(FactoryController.MODE_TOOLBOX);
+    controller.exportFile(FactoryController.MODE_PRELOAD);
+    document.getElementById('dropdownDiv_export').classList.remove("show");
+  }
 
   document.getElementById('button_add').addEventListener
       ('click', addWrapper);
@@ -608,6 +621,12 @@ goog.require('goog.ui.ColorPicker');
       ('click', separatorWrapper);
   document.getElementById('button_remove').addEventListener
       ('click', removeWrapper);
+  document.getElementById('dropdown_exportToolbox').addEventListener
+      ('click', exportToolboxWrapper);
+  document.getElementById('dropdown_exportPreload').addEventListener
+      ('click', exportPreloadWrapper);
+  document.getElementById('dropdown_exportAll').addEventListener
+      ('click', exportAllWrapper);
   document.getElementById('button_export').addEventListener
       ('click', exportWrapper);
   document.getElementById('button_print').addEventListener

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -50,7 +50,7 @@ goog.require('goog.ui.ColorPicker');
         </div>
 
         <button id="button_print">Print Toolbox</button>
-        <button id="button_clear">Clear</button>
+        <button id="button_clear">Clear Toolbox</button>
       </p>
     </td>
   </tr>
@@ -581,7 +581,7 @@ goog.require('goog.ui.ColorPicker');
     document.getElementById('dropdownDiv_export').classList.remove("show");
   };
   var clearWrapper = function() {
-    controller.clear();
+    controller.clearToolbox();
   };
   var editToolboxWrapper = function() {
     controller.setMode(FactoryController.MODE_TOOLBOX);

--- a/demos/blocklyfactory/workspacefactory/index.html
+++ b/demos/blocklyfactory/workspacefactory/index.html
@@ -685,6 +685,7 @@ goog.require('goog.ui.ColorPicker');
     // blocks when dragging them into workspace. Could cause problems if ever load
     // blocks into workspace directly without calling updatePreview.
     if (e.type == Blockly.Events.MOVE || e.type == Blockly.Events.DELETE) {
+      controller.saveStateFromWorkspace();
       controller.updatePreview();
     }
     // Listen for Blockly UI events to correctly enable the "Edit Block" button.

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -63,33 +63,6 @@ button:hover:not(:disabled)>* {
   opacity: 1;
 }
 
-label {
-  border-radius: 4px;
-  border: 1px solid #ddd;
-  background-color: #eee;
-  color: #000;
-  font-size: large;
-  margin: 0 5px;
-  padding: 10px;
-}
-
-label:hover:not(:disabled) {
-  box-shadow: 2px 2px 5px #888;
-}
-
-label:disabled {
-  opacity: .6;
-}
-
-label>* {
-  opacity: .6;
-  vertical-align: text-bottom;
-}
-
-label:hover:not(:disabled)>* {
-  opacity: 1;
-}
-
 table {
   border: none;
   border-collapse: collapse;
@@ -217,8 +190,19 @@ td {
     text-decoration: none;
 }
 
+.dropdown-content label {
+    color: black;
+    display: block;
+    padding: 12px 16px;
+    text-decoration: none;
+}
+
 /* Change color of dropdown links on hover */
 .dropdown-content a:hover {
+  background-color: #f1f1f1
+}
+
+.dropdown-content label:hover {
   background-color: #f1f1f1
 }
 

--- a/demos/blocklyfactory/workspacefactory/style.css
+++ b/demos/blocklyfactory/workspacefactory/style.css
@@ -173,28 +173,28 @@ td {
 
 /* Dropdown Content (Hidden by Default) */
 .dropdown-content {
-    background-color: #f9f9f9;
-    box-shadow: 0px 8px 16px 0px rgba(0,0,0,.2);
-    display: none;
-    min-width: 170px;
-    opacity: 1;
-    position: absolute;
-    z-index: 1;
+  background-color: #f9f9f9;
+  box-shadow: 0px 8px 16px 0px rgba(0,0,0,.2);
+  display: none;
+  min-width: 170px;
+  opacity: 1;
+  position: absolute;
+  z-index: 1;
 }
 
 /* Links inside the dropdown */
 .dropdown-content a {
-    color: black;
-    display: block;
-    padding: 12px 16px;
-    text-decoration: none;
+  color: black;
+  display: block;
+  padding: 12px 16px;
+  text-decoration: none;
 }
 
 .dropdown-content label {
-    color: black;
-    display: block;
-    padding: 12px 16px;
-    text-decoration: none;
+  color: black;
+  display: block;
+  padding: 12px 16px;
+  text-decoration: none;
 }
 
 /* Change color of dropdown links on hover */

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -249,7 +249,8 @@ FactoryController.prototype.exportFile = function(exportMode) {
     if (this.selectedMode == FactoryController.MODE_PRELOAD) {
       // Capture any changes made by user before generating XML if in
       // preload workspace mode.
-      this.model.savePreloadXml(Blockly.Xml.workspaceToDom(this.toolboxWorkspace));
+      this.model.savePreloadXml(Blockly.Xml.workspaceToDom
+          (this.toolboxWorkspace));
     }
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateWorkspaceXml());

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -288,13 +288,14 @@ FactoryController.prototype.updatePreview = function() {
     // blocks don't get cleared when updating preview from event listeners while
     // switching modes.
     this.previewWorkspace.clear();
-    Blockly.Xml.domToWorkspace(this.model.getPreloadXml(),
-        this.previewWorkspace);
+    Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
+        (this.model.getPreloadXml()), this.previewWorkspace);
   } else {
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml
-        (this.toolboxWorkspace), this.previewWorkspace);
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)),
+        this.previewWorkspace);
   }
   // Reenable events.
   Blockly.Events.enable();
@@ -516,7 +517,8 @@ FactoryController.prototype.addSeparator = function() {
  * @param {string} file The path for the file to be imported into the workspace.
  * Should contain valid toolbox XML.
  */
-FactoryController.prototype.importFile = function(file) {
+ // UPDATE COMMENTS
+FactoryController.prototype.importFile = function(file, isToolbox) {
   // Exit if cancelled.
   if (!file) {
     return;
@@ -527,12 +529,20 @@ FactoryController.prototype.importFile = function(file) {
   reader.onload = function() {
     // Try to parse XML from file and load it into toolbox editing area.
     // Print error message if fail.
-    try {
+    //try {
       var tree = Blockly.Xml.textToDom(reader.result);
-      controller.importFromTree_(tree);
-    } catch(e) {
-      alert('Cannot load XML from file.');
-    }
+      if (isToolbox) {
+        controller.setMode(FactoryController.MODE_TOOLBOX);
+        controller.importToolboxFromTree_(tree);
+      } else {
+        controller.setMode(FactoryController.MODE_PRELOAD);
+        controller.importPreloadFromTree_(tree);
+      }
+    // } catch(e) {
+    //   alert('Cannot load XML from file.');
+    //   console.log(e);
+    //   console.log(e.lineno);
+    // }
   }
 
   // Read the file.
@@ -547,7 +557,7 @@ FactoryController.prototype.importFile = function(file) {
  *
  * @param {!Element} tree XML tree to be loaded to toolbox editing area.
  */
-FactoryController.prototype.importFromTree_ = function(tree) {
+FactoryController.prototype.importToolboxFromTree_ = function(tree) {
   // Clear current editing area.
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
@@ -600,6 +610,14 @@ FactoryController.prototype.importFromTree_ = function(tree) {
 
   this.updatePreview();
 };
+
+FactoryController.prototype.importPreloadFromTree_ = function(tree) {
+  this.clearAndLoadXml_(tree);
+  this.model.savePreloadXml(tree);
+  this.updatePreview(); //assuming that updatePreview still calls domToWorkspace regardless of mode
+  // this.previewWorkspace.domToWorkspace
+  //     (this.generator.generateWorkspaceXml(tree));
+}
 
 /**
  * Clears the toolbox editing area completely, deleting all categories and all
@@ -676,6 +694,11 @@ FactoryController.prototype.convertShadowBlocks_ = function() {
  */
 FactoryController.prototype.setMode = function(mode) {
 
+  // No work to change mode that's currently set.
+  if (this.selectedMode == mode) {
+    return;
+  }
+
   // Set tab selection and display appropriate tab.
   this.view.setModeSelection(mode);
 
@@ -687,7 +710,7 @@ FactoryController.prototype.setMode = function(mode) {
     document.getElementById('editHelpText').textContent =
         'Drag blocks into your toolbox:';
     this.model.savePreloadXml(this.generator.generateWorkspaceXml
-        (this.toolboxWorkspace));
+        (Blockly.Xml.workspaceToDom(this.toolboxWorkspace)));
     this.clearAndLoadXml_(this.model.getSelectedXml());
     this.view.disableWorkspace(this.view.shouldDisableWorkspace
         (this.model.getSelected()));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -124,30 +124,41 @@ FactoryController.prototype.removeElement = function() {
   if (!this.model.getSelected()) {
     return;
   }
+
   // Check if user wants to remove current category.
   var check = confirm('Are you sure you want to delete the currently selected '
         + this.model.getSelected().type + '?');
   if (!check) { // If cancelled, exit.
     return;
   }
+
   var selectedId = this.model.getSelectedId();
   var selectedIndex = this.model.getIndexByElementId(selectedId);
   // Delete element visually.
   this.view.deleteElementRow(selectedId, selectedIndex);
   // Delete element in model.
   this.model.deleteElementFromList(selectedIndex);
+
   // Find next logical element to switch to.
   var next = this.model.getElementByIndex(selectedIndex);
   if (!next && this.model.hasToolbox()) {
     next = this.model.getElementByIndex(selectedIndex - 1);
   }
   var nextId = next ? next.id : null;
+
   // Open next element.
   this.clearAndLoadElement(nextId);
+
+  // If no element to switch to, display message, clear the workspace, and
+  // set a default selected element not in toolbox list in the model.
   if (!nextId) {
     alert('You currently have no categories or separators. All your blocks' +
         ' will be displayed in a single flyout.');
+    this.toolboxWorkspace.clear();
+    this.toolboxWorkspace.clearUndo();
+    this.model.setDefaultSelected();
   }
+
   // Update preview.
   this.updatePreview();
 };
@@ -208,17 +219,21 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
     this.view.disableWorkspace(false);
   }
 
-  // Set next category.
-  this.model.setSelectedById(id);
+  // If switching to another category, set category selection in the model and
+  // view.
+  if (id != null) {
+    // Set next category.
+    this.model.setSelectedById(id);
 
-  // Clears workspace and loads next category.
-  this.clearAndLoadXml_(this.model.getSelectedXml());
+    // Clears workspace and loads next category.
+    this.clearAndLoadXml_(this.model.getSelectedXml());
 
-  // Selects the next tab.
-  this.view.setCategoryTabSelection(id, true);
+    // Selects the next tab.
+    this.view.setCategoryTabSelection(id, true);
 
-  // Order blocks as if shown in the flyout.
-  this.toolboxWorkspace.cleanUp_();
+    // Order blocks as if shown in the flyout.
+    this.toolboxWorkspace.cleanUp_();
+  }
 
   // Update category editing buttons.
   this.view.updateState(this.model.getIndexByElementId
@@ -671,9 +686,10 @@ FactoryController.prototype.importPreloadFromTree_ = function(tree) {
 
 /**
  * Clears the toolbox editing area completely, deleting all categories and all
- * blocks in the model and view.
+ * blocks in the model and view. Sets the mode to toolbox mode.
  */
-FactoryController.prototype.clear = function() {
+FactoryController.prototype.clearToolbox = function() {
+  this.setMode(FactoryController.MODE_TOOLBOX);
   this.model.clearToolboxList();
   this.view.clearToolboxTabs();
   this.view.addEmptyCategoryMessage();

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -249,24 +249,15 @@ FactoryController.prototype.clearAndLoadElement = function(id) {
  *    FactoryController.MODE_PRELOAD for the pre-loaded workspace configuration)
  */
 FactoryController.prototype.exportFile = function(exportMode) {
+  // Save workspace in current state.
+  this.saveStateFromWorkspace();
   // Generate XML.
   if (exportMode == FactoryController.MODE_TOOLBOX) {
     // Export the toolbox XML.
-    if (this.selectedMode == FactoryController.MODE_TOOLBOX) {
-      // Capture any changes made by user before generating XML if in
-      // toolbox mode.
-      this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
-    }
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateToolboxXml());
   } else if (exportMode == FactoryController.MODE_PRELOAD) {
     // Export the pre-loaded block XML.
-    if (this.selectedMode == FactoryController.MODE_PRELOAD) {
-      // Capture any changes made by user before generating XML if in
-      // preload workspace mode.
-      this.model.savePreloadXml(Blockly.Xml.workspaceToDom
-          (this.toolboxWorkspace));
-    }
     var configXml = Blockly.Xml.domToPrettyText
         (this.generator.generateWorkspaceXml());
   } else {
@@ -292,7 +283,7 @@ FactoryController.prototype.exportFile = function(exportMode) {
  */
 FactoryController.prototype.printConfig = function() {
   // Capture any changes made by user before generating XML.
-  this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
+  this.saveStateFromWorkspace();
   // Print XML.
   window.console.log(Blockly.Xml.domToPrettyText
       (this.generator.generateToolboxXml()));

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -339,7 +339,7 @@ FactoryController.prototype.updatePreview = function() {
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
         this.previewWorkspace);
-  } else {
+  } else if (this.selectedMode == FactoryController.MODE_PRELOAD){
     // If currently editing the pre-loaded workspace.
     this.previewWorkspace.clear();
     Blockly.Xml.domToWorkspace(this.generator.generateWorkspaceXml(),
@@ -395,9 +395,8 @@ FactoryController.prototype.reinjectPreview = function(tree) {
  * currently in use, exits if user presses cancel.
  */
 FactoryController.prototype.changeCategoryName = function() {
-  // Return if no category selected or element a separator.
-  if (!this.model.getSelected() ||
-      this.model.getSelected().type == ListElement.TYPE_SEPARATOR) {
+  // Return if a category is not selected.
+  if (this.model.getSelected().type != ListElement.TYPE_CATEGORY) {
     return;
   }
   // Get new name from user.
@@ -465,9 +464,8 @@ FactoryController.prototype.moveElementToIndex = function(element, newIndex,
  * a valid CSS string.
  */
 FactoryController.prototype.changeSelectedCategoryColor = function(color) {
-  // Return if no category selected or element a separator.
-  if (!this.model.getSelected() ||
-      this.model.getSelected().type == ListElement.TYPE_SEPARATOR) {
+  // Return if category is not selected.
+  if (this.model.getSelected().type != ListElement.TYPE_CATEGORY) {
     return;
   }
   // Change color of selected category.

--- a/demos/blocklyfactory/workspacefactory/wfactory_controller.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_controller.js
@@ -483,13 +483,13 @@ FactoryController.prototype.loadCategory = function() {
     return;
   }
 
+  var firstCategory = !this.model.hasToolbox();
   // Copy the standard category in the model.
   var copy = standardCategory.copy();
   this.model.addElementToList(copy);
 
   // Update the copy in the view.
-  var tab = this.view.addCategoryRow(copy.name, copy.id,
-      this.model.getSelected() == null);
+  var tab = this.view.addCategoryRow(copy.name, copy.id, firstCategory);
   this.addClickToSwitch(tab, copy.id);
   // Color the category tab in the view.
   if (copy.color) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -106,7 +106,59 @@ FactoryGenerator.prototype.generateWorkspaceXml = function() {
   generatedXml.setAttribute('id', 'preload_blocks');
   generatedXml.setAttribute('style', 'display:none');
   return generatedXml;
- }
+ };
+
+/**
+ * Returns an array of all the block types currently being used in the toolbox
+ * and the pre-loaded blocks. No duplicates.
+ *
+ * @return {!Array<!string>} Array of block types currently being used.
+ */
+FactoryGenerator.prototype.getAllUsedBlocks = function() {
+  var blockTypeList = [];
+  if (!this.model.hasElements()) {
+    // If has a single flyout, add block types for the single flyout.
+    this.pushBlockTypesToList_(this.model.getSelectedXml(), blockTypeList);
+
+  } else {
+    // If has categories, add block types for each category.
+    var toolboxList = this.model.getToolboxList();
+
+    for (var i = 0, category; category = this.toolboxList[i]; i++) {
+      if (category.type == ListElement.TYPE_CATEGORY) {
+        this.pushBlockTypesToList_(category.xml, blockTypeList);
+      }
+    }
+  }
+
+  // Add the block types from any pre-loaded blocks.
+  this.pushBlockTypesToList_(this.model.getPreloadXml(), blockTypeList);
+
+  return blockTypeList;
+};
+
+/**
+ * Given XML for the workspace, adds all block types included in the XML to
+ * the list, not adding duplicates.
+ * @private
+ *
+ * @param {!Element} xml The XML for the workspace containing all the block
+ *    types that should be added to the list.l
+ * @param {!Array<!string>} list The array of block types to add to.
+ */
+FactoryGenerator.prototype.pushBlockTypesToList_ = function (xml, list) {
+  // Load blocks to hidden workspace.
+  this.hiddenWorkspace.clear();
+  Blockly.Xml.domToWorkspace(xml, this.hiddenWorkspace);
+  var blocks = this.hiddenWorkspace.getAllBlocks();
+
+  for (var i = 0, block; block = blocks[i]; i++) {
+    // Only add block if not contained in list.
+    if (list.indexOf(block.type) == -1) {
+      list.push(block.type);
+    }
+  }
+};
 
 /**
  * Load the given XML to the hidden workspace, set any user-generated shadow

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -46,7 +46,8 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
       });
   if (!this.model.hasElements()) {
     // Toolbox has no categories. Use XML directly from workspace.
-    this.loadToHiddenWorkspaceAndSave_(this.model.getSelectedXml(), xmlDom);
+    this.loadToHiddenWorkspace_(this.model.getSelectedXml());
+    this.appendHiddenWorkspaceToDom_(xmlDom);
   } else {
     // Toolbox has categories.
     // Assert that selected != null
@@ -80,7 +81,8 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
         }
         // Load that category to hidden workspace, setting user-generated shadow
         // blocks as real shadow blocks.
-        this.loadToHiddenWorkspaceAndSave_(element.xml, nextElement);
+        this.loadToHiddenWorkspace_(element.xml);
+        this.appendHiddenWorkspaceToDom_(nextElement);
       }
       xmlDom.appendChild(nextElement);
     }
@@ -109,19 +111,16 @@ FactoryGenerator.prototype.generateWorkspaceXml = function() {
  };
 
 /**
- * Load the given XML to the hidden workspace, set any user-generated shadow
- * blocks to be actual shadow blocks, then append the XML from the workspace
- * to the DOM element passed in.
+ * Loads the given XML to the hidden workspace and sets any user-generated
+ * shadow blocks to be actual shadow blocks.
  * @private
  *
  * @param {!Element} xml The XML to be loaded to the hidden workspace.
- * @param {!Element} dom The DOM element to append the generated XML to.
  */
-FactoryGenerator.prototype.loadToHiddenWorkspaceAndSave_ = function(xml, dom) {
+FactoryGenerator.prototype.loadToHiddenWorkspace_ = function(xml) {
   this.hiddenWorkspace.clear();
   Blockly.Xml.domToWorkspace(xml, this.hiddenWorkspace);
   this.setShadowBlocksInHiddenWorkspace_();
-  this.appendHiddenWorkspaceToDom_(dom);
 }
 
  /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -44,7 +44,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
         'id' : 'toolbox',
         'style' : 'display:none'
       });
-  if (!this.model.hasToolbox()) {
+  if (!this.model.hasElements()) {
     // Toolbox has no categories. Use XML directly from workspace.
     this.loadToHiddenWorkspaceAndSave_(this.model.getSelectedXml(), xmlDom);
   } else {

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -29,13 +29,15 @@ FactoryGenerator = function(model) {
 /**
  * Generates the xml for the toolbox or flyout with information from
  * toolboxWorkspace and the model. Uses the hiddenWorkspace to generate XML.
+ * Save state of workspace in model (saveFromWorkspace) before calling if
+ * changes might have been made to the selected category.
  *
  * @param {!Blockly.workspace} toolboxWorkspace Toolbox editing workspace where
  * blocks are added by user to be part of the toolbox.
  * @return {!Element} XML element representing toolbox or flyout corresponding
  * to toolbox workspace.
  */
-FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
+FactoryGenerator.prototype.generateToolboxXml = function() {
   // Create DOM for XML.
   var xmlDom = goog.dom.createDom('xml',
       {
@@ -44,8 +46,7 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
       });
   if (!this.model.hasToolbox()) {
     // Toolbox has no categories. Use XML directly from workspace.
-    this.loadToHiddenWorkspaceAndSave_
-        (Blockly.Xml.workspaceToDom(toolboxWorkspace), xmlDom);
+    this.loadToHiddenWorkspaceAndSave_(this.model.getSelectedXml(), xmlDom);
   } else {
     // Toolbox has categories.
     // Assert that selected != null
@@ -53,8 +54,6 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
       throw new Error('Selected is null when the toolbox is empty.');
     }
 
-    // Capture any changes made by user before generating XML.
-    this.model.getSelected().saveFromWorkspace(toolboxWorkspace);
     var xml = this.model.getSelectedXml();
     var toolboxList = this.model.getToolboxList();
 
@@ -94,15 +93,19 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   * it includes XY and ID attributes). Uses a workspace and converts user
   * generated shadow blocks to actual shadow blocks.
   *
-  * @param {!Blockly.workspace} toolboxWorkspace The workspace to load XML
-  *     from.
   */
-  // UPDATE CoMMENTS
- FactoryGenerator.prototype.generateWorkspaceXml = function(rawXml) {
+ FactoryGenerator.prototype.generateWorkspaceXml = function() {
+  // Load workspace XML to hidden workspace with user-generated shadow blocks
+  // as actual shadow blocks.
   this.hiddenWorkspace.clear();
-  Blockly.Xml.domToWorkspace(rawXml, this.hiddenWorkspace);
+  Blockly.Xml.domToWorkspace(this.model.getPreloadXml(), this.hiddenWorkspace);
   this.setShadowBlocksInHiddenWorkspace_();
-  return Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
+
+  // Generate XML and set attributes.
+  var generatedXml = Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
+  generatedXml.setAttribute('id', 'preload_blocks');
+  generatedXml.setAttribute('style', 'display:none');
+  return generatedXml;
  }
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -94,7 +94,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
   * generated shadow blocks to actual shadow blocks.
   *
   */
- FactoryGenerator.prototype.generateWorkspaceXml = function() {
+FactoryGenerator.prototype.generateWorkspaceXml = function() {
   // Load workspace XML to hidden workspace with user-generated shadow blocks
   // as actual shadow blocks.
   this.hiddenWorkspace.clear();

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -109,58 +109,6 @@ FactoryGenerator.prototype.generateWorkspaceXml = function() {
  };
 
 /**
- * Returns an array of all the block types currently being used in the toolbox
- * and the pre-loaded blocks. No duplicates.
- *
- * @return {!Array<!string>} Array of block types currently being used.
- */
-FactoryGenerator.prototype.getAllUsedBlocks = function() {
-  var blockTypeList = [];
-  if (!this.model.hasElements()) {
-    // If has a single flyout, add block types for the single flyout.
-    this.pushBlockTypesToList_(this.model.getSelectedXml(), blockTypeList);
-
-  } else {
-    // If has categories, add block types for each category.
-    var toolboxList = this.model.getToolboxList();
-
-    for (var i = 0, category; category = this.toolboxList[i]; i++) {
-      if (category.type == ListElement.TYPE_CATEGORY) {
-        this.pushBlockTypesToList_(category.xml, blockTypeList);
-      }
-    }
-  }
-
-  // Add the block types from any pre-loaded blocks.
-  this.pushBlockTypesToList_(this.model.getPreloadXml(), blockTypeList);
-
-  return blockTypeList;
-};
-
-/**
- * Given XML for the workspace, adds all block types included in the XML to
- * the list, not adding duplicates.
- * @private
- *
- * @param {!Element} xml The XML for the workspace containing all the block
- *    types that should be added to the list.l
- * @param {!Array<!string>} list The array of block types to add to.
- */
-FactoryGenerator.prototype.pushBlockTypesToList_ = function (xml, list) {
-  // Load blocks to hidden workspace.
-  this.hiddenWorkspace.clear();
-  Blockly.Xml.domToWorkspace(xml, this.hiddenWorkspace);
-  var blocks = this.hiddenWorkspace.getAllBlocks();
-
-  for (var i = 0, block; block = blocks[i]; i++) {
-    // Only add block if not contained in list.
-    if (list.indexOf(block.type) == -1) {
-      list.push(block.type);
-    }
-  }
-};
-
-/**
  * Load the given XML to the hidden workspace, set any user-generated shadow
  * blocks to be actual shadow blocks, then append the XML from the workspace
  * to the DOM element passed in.

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -97,10 +97,10 @@ FactoryGenerator.prototype.generateConfigXml = function(toolboxWorkspace) {
   * @param {!Blockly.workspace} toolboxWorkspace The workspace to load XML
   *     from.
   */
- FactoryGenerator.prototype.generateWorkspaceXml = function(toolboxWorkspace) {
+  // UPDATE CoMMENTS
+ FactoryGenerator.prototype.generateWorkspaceXml = function(rawXml) {
   this.hiddenWorkspace.clear();
-  Blockly.Xml.domToWorkspace(Blockly.Xml.workspaceToDom(toolboxWorkspace),
-      this.hiddenWorkspace);
+  Blockly.Xml.domToWorkspace(rawXml, this.hiddenWorkspace);
   this.setShadowBlocksInHiddenWorkspace_();
   return Blockly.Xml.workspaceToDom(this.hiddenWorkspace);
  }

--- a/demos/blocklyfactory/workspacefactory/wfactory_generator.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_generator.js
@@ -66,7 +66,7 @@ FactoryGenerator.prototype.generateToolboxXml = function() {
       if (element.type == ListElement.TYPE_SEPARATOR) {
         // If the next element is a separator.
         var nextElement = goog.dom.createDom('sep');
-      } else {
+      } else if (element.type == ListElement.TYPE_CATEGORY) {
         // If the next element is a category.
         var nextElement = goog.dom.createDom('category');
         nextElement.setAttribute('name', element.name);

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -71,9 +71,9 @@ FactoryModel.prototype.hasProcedures = function() {
  * Determines if the user has any elements in the toolbox. Uses the length of
  * toolboxList.
  *
- * @return {boolean} True if categories exist, false otherwise.
+ * @return {boolean} True if elements exist, false otherwise.
  */
-FactoryModel.prototype.hasToolbox = function() {
+FactoryModel.prototype.hasElements = function() {
   return this.toolboxList.length > 0;
 };
 
@@ -109,17 +109,16 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
       false : this.hasProcedureCategory;
   // Remove element.
   this.toolboxList.splice(index, 1);
-  // If removing last element from toolbox list, create empty list element
-  // for single flyout.
-
 };
 
 /**
  * Sets selected to be an empty category not in toolbox list if toolbox list
  * is empty. Should be called when removing the last element from toolbox list.
+ * If the toolbox list is empty, selected stores the XML for the single flyout
+ * of blocks displayed.
  *
  */
-FactoryModel.prototype.setDefaultSelected = function() {
+FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
   if (this.toolboxList.length == 0) {
     this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   }

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -387,7 +387,7 @@ FactoryModel.prototype.getAllUsedBlockTypes = function() {
  * which are marked as "block" in XML.
  *
  * @param {!Element} xml The XML for the workspace containing all the block
- *    types that should be added to the list.l
+ *    types that should be added to the list.
  * @param {!Array<!string>} list The array of block types to add to.
  */
 FactoryModel.prototype.pushBlockTypesToList = function (xml, list) {

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -353,6 +353,59 @@ FactoryModel.prototype.getPreloadXml = function() {
 };
 
 /**
+ * Returns an array of all the block types currently being used in the toolbox
+ * and the pre-loaded blocks. No duplicates.
+ *
+ * @return {!Array<!string>} Array of block types currently being used.
+ */
+FactoryModel.prototype.getAllUsedBlockTypes = function() {
+  var blockTypeList = [];
+  console.log(this.getSelectedXml());
+  if (this.flyout) {
+    // If has a single flyout, add block types for the single flyout.
+
+    this.pushBlockTypesToList_(this.getSelectedXml(), blockTypeList);
+  } else {
+    // If has categories, add block types for each category.
+
+    for (var i = 0, category; category = this.toolboxList[i]; i++) {
+      if (category.type == ListElement.TYPE_CATEGORY) {
+        this.pushBlockTypesToList_(category.xml, blockTypeList);
+      }
+    }
+  }
+
+  // Add the block types from any pre-loaded blocks.
+  this.pushBlockTypesToList_(this.getPreloadXml(), blockTypeList);
+
+  return blockTypeList;
+}
+
+/**
+ * Given XML for the workspace, adds all block types included in the XML to
+ * the list, not adding duplicates. Don't need to consider shadow blocks
+ * because all shadow blocks are transformed to user-generated shadow blocks
+ * which are marked as "block" in XML.
+ * @private
+ *
+ * @param {!Element} xml The XML for the workspace containing all the block
+ *    types that should be added to the list.l
+ * @param {!Array<!string>} list The array of block types to add to.
+ */
+FactoryModel.prototype.pushBlockTypesToList_ = function (xml, list) {
+  // Get all block XML nodes.
+  var blocks = xml.getElementsByTagName('block');
+
+  // Add block types if not already in list.
+  for (var i = 0; i < blocks.length; i++) {
+    var type = blocks[i].getAttribute('type');
+    if (list.indexOf(type) == -1) {
+      list.push(type);
+    }
+  }
+};
+
+/**
  * Class for a ListElement.
  * @constructor
  */

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -360,23 +360,22 @@ FactoryModel.prototype.getPreloadXml = function() {
  */
 FactoryModel.prototype.getAllUsedBlockTypes = function() {
   var blockTypeList = [];
-  console.log(this.getSelectedXml());
+
   if (this.flyout) {
     // If has a single flyout, add block types for the single flyout.
-
-    this.pushBlockTypesToList_(this.getSelectedXml(), blockTypeList);
+    this.pushBlockTypesToList(this.getSelectedXml(), blockTypeList);
   } else {
     // If has categories, add block types for each category.
 
     for (var i = 0, category; category = this.toolboxList[i]; i++) {
       if (category.type == ListElement.TYPE_CATEGORY) {
-        this.pushBlockTypesToList_(category.xml, blockTypeList);
+        this.pushBlockTypesToList(category.xml, blockTypeList);
       }
     }
   }
 
   // Add the block types from any pre-loaded blocks.
-  this.pushBlockTypesToList_(this.getPreloadXml(), blockTypeList);
+  this.pushBlockTypesToList(this.getPreloadXml(), blockTypeList);
 
   return blockTypeList;
 }
@@ -386,13 +385,12 @@ FactoryModel.prototype.getAllUsedBlockTypes = function() {
  * the list, not adding duplicates. Don't need to consider shadow blocks
  * because all shadow blocks are transformed to user-generated shadow blocks
  * which are marked as "block" in XML.
- * @private
  *
  * @param {!Element} xml The XML for the workspace containing all the block
  *    types that should be added to the list.l
  * @param {!Array<!string>} list The array of block types to add to.
  */
-FactoryModel.prototype.pushBlockTypesToList_ = function (xml, list) {
+FactoryModel.prototype.pushBlockTypesToList = function (xml, list) {
   // Get all block XML nodes.
   var blocks = xml.getElementsByTagName('block');
 

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -355,11 +355,27 @@ FactoryModel.prototype.getPreloadXml = function() {
 /**
  * Returns an array of all the block types currently being used in the toolbox
  * and the pre-loaded blocks. No duplicates.
+ * TODO(evd2014): Move pushBlockTypesToList to FactoryUtils.
  *
  * @return {!Array<!string>} Array of block types currently being used.
  */
 FactoryModel.prototype.getAllUsedBlockTypes = function() {
   var blockTypeList = [];
+
+  // Given XML for the workspace, adds all block types included in the XML
+  // to the list, not including duplicates.
+  var pushBlockTypesToList = function (xml, list) {
+    // Get all block XML nodes.
+    var blocks = xml.getElementsByTagName('block');
+
+    // Add block types if not already in list.
+    for (var i = 0; i < blocks.length; i++) {
+      var type = blocks[i].getAttribute('type');
+      if (list.indexOf(type) == -1) {
+        list.push(type);
+      }
+    }
+  };
 
   if (this.flyout) {
     // If has a single flyout, add block types for the single flyout.
@@ -379,29 +395,6 @@ FactoryModel.prototype.getAllUsedBlockTypes = function() {
 
   return blockTypeList;
 }
-
-/**
- * Given XML for the workspace, adds all block types included in the XML to
- * the list, not adding duplicates. Don't need to consider shadow blocks
- * because all shadow blocks are transformed to user-generated shadow blocks
- * which are marked as "block" in XML.
- *
- * @param {!Element} xml The XML for the workspace containing all the block
- *    types that should be added to the list.
- * @param {!Array<!string>} list The array of block types to add to.
- */
-FactoryModel.prototype.pushBlockTypesToList = function (xml, list) {
-  // Get all block XML nodes.
-  var blocks = xml.getElementsByTagName('block');
-
-  // Add block types if not already in list.
-  for (var i = 0; i < blocks.length; i++) {
-    var type = blocks[i].getAttribute('type');
-    if (list.indexOf(type) == -1) {
-      list.push(type);
-    }
-  }
-};
 
 /**
  * Class for a ListElement.

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -109,6 +109,11 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
       false : this.hasProcedureCategory;
   // Remove element.
   this.toolboxList.splice(index, 1);
+  // If removing last element from toolbox list, create empty list element
+  // for single flyout.
+  if (this.toolboxList.length == 0) {
+    this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+  }
 };
 
 /**

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -21,8 +21,8 @@ FactoryModel = function() {
   this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // Currently selected ListElement. In toolboxList if there are categories, in
-  // flyout if all blocks are displayed in a single flyout.
+  // Reference to currently selected ListElement. Stored in toolboxList if there
+  // are categories, or in flyout if blocks are displayed in a single flyout.
   this.selected = this.flyout;
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
@@ -383,11 +383,11 @@ ListElement.TYPE_FLYOUT = 'flyout';
  * from.
  */
 ListElement.prototype.saveFromWorkspace = function(workspace) {
-  // Don't save anything from separators.
-  if (this.type == ListElement.TYPE_SEPARATOR) {
-    return;
+  // Only save XML for categories and flyouts.
+  if (this.type == ListElement.TYPE_FLYOUT ||
+      this.type == ListElement.TYPE_CATEGORY) {
+    this.xml = Blockly.Xml.workspaceToDom(workspace);
   }
-  this.xml = Blockly.Xml.workspaceToDom(workspace);
 };
 
 
@@ -399,7 +399,7 @@ ListElement.prototype.saveFromWorkspace = function(workspace) {
  */
 ListElement.prototype.changeName = function (name) {
   // Only update list elements that are categories.
-  if (this.type == ListElement.TYPE_CATEGORY) {
+  if (this.type != ListElement.TYPE_CATEGORY) {
     return;
   }
   this.name = name;

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -15,13 +15,15 @@
  * @constructor
  */
 FactoryModel = function() {
-  // Ordered list of ListElement objects.
+  // Ordered list of ListElement objects. Empty if there is a single flyout.
   this.toolboxList = [];
+  // ListElement for blocks in a single flyout. Null if a toolbox exists.
+  this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
   // Array of block IDs for all user created shadow blocks.
   this.shadowBlocks = [];
-  // Currently selected ListElement. In list if there are categories, not in
-  // list if there is only a single flyout.
-  this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+  // Currently selected ListElement. In toolboxList if there are categories, in
+  // flyout if all blocks are displayed in a single flyout.
+  this.selected = this.flyout;
   // Boolean for if a Variable category has been added.
   this.hasVariableCategory = false;
   // Boolean for if a Procedure category has been added.
@@ -90,6 +92,8 @@ FactoryModel.prototype.addElementToList = function(element) {
       this.hasProcedureCategory;
   // Add element to toolboxList.
   this.toolboxList.push(element);
+  // Empty single flyout.
+  this.flyout = null;
 };
 
 /**
@@ -112,15 +116,14 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
 };
 
 /**
- * Sets selected to be an empty category not in toolbox list if toolbox list
- * is empty. Should be called when removing the last element from toolbox list.
- * If the toolbox list is empty, selected stores the XML for the single flyout
- * of blocks displayed.
+ * Sets selected to be an empty single flyout if toolbox list is empty. Should
+ * be called when removing the last element from toolbox list.
  *
  */
 FactoryModel.prototype.createDefaultSelectedIfEmpty = function() {
   if (this.toolboxList.length == 0) {
-    this.selected = new ListElement(ListElement.TYPE_CATEGORY);
+    this.flyout = new ListElement(ListElement.TYPE_FLYOUT);
+    this.selected = this.flyout;
   }
 }
 
@@ -370,6 +373,7 @@ ListElement = function(type, opt_name) {
 // List element types.
 ListElement.TYPE_CATEGORY = 'category';
 ListElement.TYPE_SEPARATOR = 'separator';
+ListElement.TYPE_FLYOUT = 'flyout';
 
 /**
  * Saves a category by updating its XML (does not save XML for
@@ -379,8 +383,8 @@ ListElement.TYPE_SEPARATOR = 'separator';
  * from.
  */
 ListElement.prototype.saveFromWorkspace = function(workspace) {
-  // Only save list elements that are categories.
-  if (this.type != ListElement.TYPE_CATEGORY) {
+  // Don't save anything from separators.
+  if (this.type == ListElement.TYPE_SEPARATOR) {
     return;
   }
   this.xml = Blockly.Xml.workspaceToDom(workspace);
@@ -395,7 +399,7 @@ ListElement.prototype.saveFromWorkspace = function(workspace) {
  */
 ListElement.prototype.changeName = function (name) {
   // Only update list elements that are categories.
-  if (this.type != ListElement.TYPE_CATEGORY) {
+  if (this.type == ListElement.TYPE_CATEGORY) {
     return;
   }
   this.name = name;

--- a/demos/blocklyfactory/workspacefactory/wfactory_model.js
+++ b/demos/blocklyfactory/workspacefactory/wfactory_model.js
@@ -111,10 +111,19 @@ FactoryModel.prototype.deleteElementFromList = function(index) {
   this.toolboxList.splice(index, 1);
   // If removing last element from toolbox list, create empty list element
   // for single flyout.
+
+};
+
+/**
+ * Sets selected to be an empty category not in toolbox list if toolbox list
+ * is empty. Should be called when removing the last element from toolbox list.
+ *
+ */
+FactoryModel.prototype.setDefaultSelected = function() {
   if (this.toolboxList.length == 0) {
     this.selected = new ListElement(ListElement.TYPE_CATEGORY);
   }
-};
+}
 
 /**
  * Moves a list element to a certain position in toolboxList by removing it


### PR DESCRIPTION
Added function in generator that returns an array of all the block types being used without any duplicates. For use in integrating with Blockly Factory to allow the exporter to know which blocks are being used in the toolbox and pre-loaded blocks. This will allow the exporter to be able to automatically add all blocks currently being used in workspace factory to the selector workspace.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/evd2014/blockly/42)

<!-- Reviewable:end -->
